### PR TITLE
Add result summary next to Results heading

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -6,6 +6,7 @@ const previewSection = document.getElementById("preview-section");
 const previewCanvas = document.getElementById("preview-canvas");
 const resultsSection = document.getElementById("results-section");
 const resultsContainer = document.getElementById("results");
+const resultsSummary = document.getElementById("results-summary");
 const noResults = document.getElementById("no-results");
 const errorSection = document.getElementById("error-section");
 const errorMessage = document.getElementById("error-message");
@@ -117,6 +118,19 @@ async function handleFile(file) {
   }
 }
 
+function formatTypeLabel(symbolType, count) {
+  // Turn "QR-Code" → "QR code(s)", "CODE-128" → "Code 128(s)", etc.
+  const friendly = {
+    "QR-Code": "QR code",
+    "SQ-Code": "SQ code",
+    "CODE-39": "Code 39",
+    "CODE-93": "Code 93",
+    "CODE-128": "Code 128",
+  };
+  const label = friendly[symbolType] || symbolType;
+  return count === 1 ? label : `${label}s`;
+}
+
 function displayResults(results) {
   resultsContainer.innerHTML = "";
 
@@ -127,6 +141,18 @@ function displayResults(results) {
   }
 
   resultsSection.hidden = false;
+
+  // Build summary like "2 QR codes, 1 EAN-13"
+  const counts = new Map();
+  for (const r of results) {
+    counts.set(r.symbolType, (counts.get(r.symbolType) || 0) + 1);
+  }
+  const parts = [];
+  for (const [type, count] of counts) {
+    const label = formatTypeLabel(type, count);
+    parts.push(`${count}\u00a0${label}`);
+  }
+  resultsSummary.textContent = parts.length ? `\u2014 ${parts.join(", ")}` : "";
 
   for (const result of results) {
     const data = result.data;

--- a/demo/index.html
+++ b/demo/index.html
@@ -63,7 +63,7 @@
       </div>
 
       <div id="results-section" hidden>
-        <h3>Results</h3>
+        <h3>Results <span id="results-summary" class="results-summary"></span></h3>
         <div id="results"></div>
       </div>
 

--- a/demo/index.src.html
+++ b/demo/index.src.html
@@ -57,7 +57,7 @@
       </div>
 
       <div id="results-section" hidden>
-        <h3>Results</h3>
+        <h3>Results <span id="results-summary" class="results-summary"></span></h3>
         <div id="results"></div>
       </div>
 

--- a/demo/style.css
+++ b/demo/style.css
@@ -242,6 +242,12 @@ h3 {
 }
 
 /* Results */
+.results-summary {
+  font-weight: 400;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
 .result-card {
   background: var(--surface);
   border: 1px solid var(--border);


### PR DESCRIPTION
Show an understated summary of scanned codes (e.g. "2 QR codes, 1 EAN-13")
next to the Results heading using muted text.

https://claude.ai/code/session_01DTQLA9oL2H33ihgfFoYk7v