### PR TITLE
fix: allow reading binary QR/SQ code data

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -177,9 +177,11 @@ function displayResults(results) {
     const tabs = document.createElement("div");
     tabs.className = "view-tabs";
 
+    const hasText = text !== undefined && text !== null;
+    const isBinary = !hasText || isBinaryData(data);
     const views = [];
 
-    if (text !== undefined && text !== null) {
+    if (hasText) {
       views.push({ label: "Text", id: "text" });
     }
     views.push({ label: "Hex", id: "hex" });
@@ -232,9 +234,28 @@ function displayResults(results) {
       if (btn) showView(btn.dataset.view);
     });
 
-    // Show first tab
-    showView(views[0].id);
+    // Show text tab for text data, hex tab for binary data
+    showView(isBinary ? "hex" : views[0].id);
   }
+}
+
+// -- Binary detection --
+
+/**
+ * Heuristic: data is likely binary if it contains control characters
+ * (other than common whitespace: TAB, LF, CR) or null bytes.
+ *
+ * Intentionally conservative — a QR code containing e.g. a BEL (0x07) in
+ * otherwise-text data will be treated as binary, which is acceptable since
+ * the text view is still available as a tab.
+ */
+function isBinaryData(data) {
+  for (let i = 0; i < data.length; i++) {
+    const b = data[i];
+    if (b === 0) return true;
+    if (b < 0x20 && b !== 0x09 && b !== 0x0a && b !== 0x0d) return true;
+  }
+  return false;
 }
 
 // -- Hex dump --

--- a/examples/scanner_api.rs
+++ b/examples/scanner_api.rs
@@ -38,11 +38,10 @@ fn main() {
     let _scanner = Scanner::with_config(config);
     println!("   Code39: length 4-20, checksum validation, uncertainty=2\n");
 
-    // Example 4: Configure QR code for binary data
-    println!("4. Scanner optimized for QR codes with binary data:");
+    // Example 4: Configure scanner for QR codes only
+    println!("4. Scanner optimized for QR codes:");
     let config = DecoderConfig::new()
         .enable(QrCode)
-        .set_binary(QrCode, true) // Preserve binary data
         .disable(Ean13) // Only scan QR codes
         .disable(Code39);
 
@@ -114,8 +113,7 @@ fn main() {
         .enable(Code39)
         .enable(QrCode)
         .enable(Databar)
-        .set_length_limits(Code128, 1, 256) // Accept any length
-        .set_binary(QrCode, true); // Binary data in QR codes
+        .set_length_limits(Code128, 1, 256); // Accept any length
 
     let _scanner = Scanner::with_config(config);
     println!("    Code128, Code39, QR, DataBar with flexible settings\n");

--- a/src/bin/zedbarimg.rs
+++ b/src/bin/zedbarimg.rs
@@ -337,8 +337,9 @@ fn main() {
             let data_bytes = symbol.data();
 
             if args.raw {
-                // Raw mode: just output the data bytes with newline
-                std::io::stdout().write_all(data_bytes).ok();
+                // Raw mode: output the raw bytes (before encoding conversion) with newline
+                let raw_bytes = symbol.raw_data().unwrap_or(data_bytes);
+                std::io::stdout().write_all(raw_bytes).ok();
                 println!();
             } else {
                 // Normal mode: include symbol type

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,6 @@
 //!     .enable(Ean13)
 //!     .enable(Code39)
 //!     .set_length_limits(Code39, 4, 20)   // ✓ Code39 supports variable length
-//!     .set_binary(QrCode, true)           // ✓ QR codes support binary mode
 //!     .position_tracking(true);
 //! ```
 //!
@@ -30,14 +29,6 @@
 //! # let config = DecoderConfig::new();
 //! // ❌ EAN-13 has fixed length, doesn't support length limits
 //! config.set_length_limits(Ean13, 1, 20);
-//! ```
-//!
-//! ```compile_fail
-//! # use zedbar::config::*;
-//! # use zedbar::DecoderConfig;
-//! # let config = DecoderConfig::new();
-//! // ❌ Code39 is not a 2D code, doesn't support binary mode
-//! config.set_binary(Code39, true);
 //! ```
 //!
 //! ```compile_fail
@@ -118,9 +109,6 @@ pub trait SupportsChecksum: Symbology {}
 /// Marker trait for symbologies that support variable length limits
 pub trait SupportsLengthLimits: Symbology {}
 
-/// Marker trait for symbologies that support binary mode
-pub trait SupportsBinary: Symbology {}
-
 /// Marker trait for symbologies that support uncertainty configuration
 pub trait SupportsUncertainty: Symbology {}
 
@@ -164,9 +152,6 @@ pub struct DecoderConfig {
     /// Length limits: (min, max)
     pub(crate) length_limits: HashMap<SymbolType, (u32, u32)>,
 
-    /// Binary mode enabled for 2D codes
-    pub(crate) binary_mode: HashSet<SymbolType>,
-
     /// Uncertainty threshold per symbology
     pub(crate) uncertainty: HashMap<SymbolType, u32>,
 
@@ -198,7 +183,6 @@ impl DecoderConfig {
             enabled: HashSet::new(),
             checksum_flags: HashMap::new(),
             length_limits: HashMap::new(),
-            binary_mode: HashSet::new(),
             uncertainty: HashMap::new(),
             position_tracking: true,
             test_inverted: false,
@@ -318,18 +302,6 @@ impl DecoderConfig {
         assert!(min <= max, "min length must be <= max length");
         assert!(max <= 256, "max length must be <= 256");
         self.length_limits.insert(S::TYPE, (min, max));
-        self
-    }
-
-    /// Enable or disable binary mode for 2D codes
-    ///
-    /// When enabled, binary data is preserved without text conversion.
-    pub fn set_binary<S: Symbology + SupportsBinary>(mut self, _: S, enabled: bool) -> Self {
-        if enabled {
-            self.binary_mode.insert(S::TYPE);
-        } else {
-            self.binary_mode.remove(&S::TYPE);
-        }
         self
     }
 
@@ -458,17 +430,6 @@ mod tests {
             Some(&(1, 50))
         );
         assert_eq!(config.length_limits.get(&SymbolType::I25), Some(&(6, 30)));
-    }
-
-    #[test]
-    fn test_type_safe_binary_mode() {
-        // Only 2D codes support binary mode
-        let config = DecoderConfig::new()
-            .set_binary(QrCode, true)
-            .set_binary(SqCode, false);
-
-        assert!(config.binary_mode.contains(&SymbolType::QrCode));
-        assert!(!config.binary_mode.contains(&SymbolType::SqCode));
     }
 
     #[test]

--- a/src/config/internal.rs
+++ b/src/config/internal.rs
@@ -32,9 +32,6 @@ pub(crate) struct SymbologyConfig {
     /// Length limits (None if not applicable)
     pub(crate) length_limits: Option<LengthLimits>,
 
-    /// Binary mode (for 2D codes)
-    pub(crate) binary_mode: bool,
-
     /// Uncertainty threshold for edge detection
     pub(crate) uncertainty: u32,
 }
@@ -113,11 +110,6 @@ impl From<&DecoderConfig> for DecoderState {
                 sym_config.length_limits = Some(LengthLimits { min, max });
             }
 
-            // Set binary mode if present
-            if config.binary_mode.contains(&sym) {
-                sym_config.binary_mode = true;
-            }
-
             // Set uncertainty if present
             if let Some(&threshold) = config.uncertainty.get(&sym) {
                 sym_config.uncertainty = threshold;
@@ -136,7 +128,6 @@ impl From<&DecoderConfig> for DecoderState {
 
                 let has_config = config.checksum_flags.contains_key(&sym)
                     || config.length_limits.contains_key(&sym)
-                    || config.binary_mode.contains(&sym)
                     || config.uncertainty.contains_key(&sym);
 
                 if has_config {
@@ -149,10 +140,6 @@ impl From<&DecoderConfig> for DecoderState {
 
                     if let Some(&(min, max)) = config.length_limits.get(&sym) {
                         sym_config.length_limits = Some(LengthLimits { min, max });
-                    }
-
-                    if config.binary_mode.contains(&sym) {
-                        sym_config.binary_mode = true;
                     }
 
                     if let Some(&threshold) = config.uncertainty.get(&sym) {

--- a/src/config/symbologies.rs
+++ b/src/config/symbologies.rs
@@ -295,12 +295,6 @@ impl SupportsLengthLimits for Code93 {}
 #[cfg(feature = "code128")]
 impl SupportsLengthLimits for Code128 {}
 
-// SupportsBinary - 2D codes only
-#[cfg(feature = "qrcode")]
-impl SupportsBinary for QrCode {}
-#[cfg(feature = "sqcode")]
-impl SupportsBinary for SqCode {}
-
 // SupportsUncertainty - most symbologies
 #[cfg(feature = "i25")]
 impl SupportsUncertainty for I25 {}

--- a/src/img_scanner.rs
+++ b/src/img_scanner.rs
@@ -584,10 +584,6 @@ impl ImageScanner {
             .map(|l| (l.min, l.max))
     }
 
-    pub(crate) fn is_binary_mode(&self, sym: SymbolType) -> bool {
-        self.config.get(sym).map(|c| c.binary_mode).unwrap_or(false)
-    }
-
     /// Reset decoder to initial state
     pub(crate) fn decoder_reset(&mut self) {
         self.idx = 0;
@@ -985,8 +981,7 @@ impl ImageScanner {
         // Decode QR and SQ codes
         #[cfg(feature = "qrcode")]
         {
-            let raw_binary = self.is_binary_mode(SymbolType::QrCode);
-            let (qr_symbols, region) = self.qr.decode(img, raw_binary);
+            let (qr_symbols, region) = self.qr.decode(img);
             for sym in qr_symbols {
                 self.add_symbol(sym);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,6 @@
 //! let config = DecoderConfig::new()
 //!     .enable(QrCode)
 //!     .enable(Ean13)
-//!     .set_binary(QrCode, true)          // Preserve binary data in QR codes
 //!     .set_length_limits(Code39, 4, 20)  // Code39 must be 4-20 chars
 //!     .test_inverted(true)               // Try inverted image if no symbols found
 //!     .retry_undecoded_regions(true)     // Crop+upscale small QR codes automatically

--- a/src/qrcode/qrdec.rs
+++ b/src/qrcode/qrdec.rs
@@ -3994,11 +3994,7 @@ impl QrReader {
     /// Returns decoded symbols and a bounding box of the finder line
     /// region when decoding fails. The bbox is computed in O(n) before
     /// `finder_centers_locate` consumes the lines.
-    pub(crate) fn decode(
-        &mut self,
-        img: &mut ImageData,
-        raw_binary: bool,
-    ) -> (Vec<Symbol>, Option<BBox>) {
+    pub(crate) fn decode(&mut self, img: &mut ImageData) -> (Vec<Symbol>, Option<BBox>) {
         // Compute an O(n) bounding box while the lines are still available.
         // finder_centers_locate will consume them.
         let fail_bbox = self.finder_line_bbox();
@@ -4026,7 +4022,7 @@ impl QrReader {
         );
 
         let symbols = if !qrlist.qrdata.is_empty() {
-            qrlist.extract_text(raw_binary)
+            qrlist.extract_text()
         } else {
             vec![]
         };
@@ -4638,7 +4634,7 @@ pub(crate) struct qr_code_data_list {
 }
 
 impl qr_code_data_list {
-    pub(crate) fn extract_text(&self, raw_binary: bool) -> Vec<Symbol> {
+    pub(crate) fn extract_text(&self) -> Vec<Symbol> {
         let mut symbols = vec![];
 
         let qrdata = &self.qrdata;
@@ -4710,12 +4706,16 @@ impl qr_code_data_list {
                 }
 
                 let mut sa_text: Vec<u8> = Vec::with_capacity(sa_ctext + 1);
+                let mut sa_raw: Vec<u8> = Vec::with_capacity(sa_ctext + 1);
                 if fnc1 == Modifier::Aim.bit() {
                     if fnc1_2ai < 100 {
                         sa_text.push(b'0' + (fnc1_2ai / 10) as u8);
                         sa_text.push(b'0' + (fnc1_2ai % 10) as u8);
+                        sa_raw.push(b'0' + (fnc1_2ai / 10) as u8);
+                        sa_raw.push(b'0' + (fnc1_2ai % 10) as u8);
                     } else {
                         sa_text.push((fnc1_2ai - 100) as u8);
+                        sa_raw.push((fnc1_2ai - 100) as u8);
                     }
                 }
 
@@ -4764,6 +4764,7 @@ impl qr_code_data_list {
                                 qr_code_data_payload::Bytes(_) | qr_code_data_payload::Kanji(_)
                             )
                         {
+                            sa_raw.extend_from_slice(&bytebuf);
                             // convert bytes to text
                             if let Some(enc) = eci {
                                 let (res, _enc, had_errors) = enc.decode(&bytebuf);
@@ -4772,8 +4773,6 @@ impl qr_code_data_list {
                                     break;
                                 }
                                 sa_text.extend_from_slice(res.as_bytes());
-                            } else if raw_binary {
-                                sa_text.extend_from_slice(&bytebuf);
                             } else {
                                 if has_kanji {
                                     enc_list_mtf(&mut enc_list, SHIFT_JIS);
@@ -4820,6 +4819,7 @@ impl qr_code_data_list {
                             qr_code_data_payload::Numeric(data)
                             | qr_code_data_payload::Alphanumeric(data) => {
                                 sa_text.extend_from_slice(data);
+                                sa_raw.extend_from_slice(data);
                             }
                             qr_code_data_payload::Bytes(data)
                             | qr_code_data_payload::Kanji(data) => {
@@ -4844,6 +4844,7 @@ impl qr_code_data_list {
                 }
 
                 if !err && !bytebuf.is_empty() {
+                    sa_raw.extend_from_slice(&bytebuf);
                     // convert bytes to text
                     if let Some(enc) = eci {
                         let (res, _enc, had_errors) = enc.decode(&bytebuf);
@@ -4852,8 +4853,6 @@ impl qr_code_data_list {
                         } else {
                             sa_text.extend_from_slice(res.as_bytes());
                         }
-                    } else if raw_binary {
-                        sa_text.extend_from_slice(&bytebuf);
                     } else {
                         if has_kanji {
                             enc_list_mtf(&mut enc_list, SHIFT_JIS);
@@ -4901,11 +4900,13 @@ impl qr_code_data_list {
 
                 if !err {
                     sa_text.shrink_to_fit();
+                    sa_raw.shrink_to_fit();
 
                     if sa_size == 1 {
                         // Single QR code - add it directly
                         if let Some(mut sym) = component_syms.into_iter().next() {
                             sym.data = sa_text;
+                            sym.raw_data = Some(sa_raw);
                             sym.modifiers = fnc1;
                             symbols.push(sym);
                         }
@@ -4914,6 +4915,7 @@ impl qr_code_data_list {
                         let mut sa_sym = Symbol::new(SymbolType::QrCode);
                         sa_sym.components = component_syms;
                         sa_sym.data = sa_text;
+                        sa_sym.raw_data = Some(sa_raw);
                         sa_sym.modifiers = fnc1;
                         symbols.push(sa_sym);
                     }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -161,7 +161,6 @@ impl std::ops::Deref for ScanResult {
 /// let config = DecoderConfig::new()
 ///     .enable(Ean13)
 ///     .enable(QrCode)
-///     .set_binary(QrCode, true)
 ///     .position_tracking(true)
 ///     .scan_density(1, 1);
 ///

--- a/src/sqcode.rs
+++ b/src/sqcode.rs
@@ -397,6 +397,7 @@ fn sq_extract_text(buf: &[u8], len: usize) -> Result<Symbol, ()> {
         None => return Err(()),
     };
 
+    sym.raw_data = Some(buf[..len].to_vec());
     sym.data = encoded;
     Ok(sym)
 }

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -46,6 +46,7 @@ pub struct Symbol {
     symbol_type: SymbolType,
     pub(crate) modifiers: u32,
     pub(crate) data: Vec<u8>,
+    pub(crate) raw_data: Option<Vec<u8>>,
     pub(crate) pts: Vec<qr_point>,
     pub(crate) orientation: Orientation,
     pub(crate) components: Vec<Symbol>,
@@ -86,9 +87,32 @@ impl Symbol {
         self.symbol_type
     }
 
-    /// Get the decoded data as bytes
+    /// Get the decoded data as bytes.
+    ///
+    /// For QR codes, this is the text-decoded output after encoding detection
+    /// (UTF-8, Shift-JIS, Windows-1252, etc.). For SQ codes, this is the
+    /// base64-encoded payload. Use [`raw_data`](Self::raw_data) to get the
+    /// original bytes before conversion.
+    ///
+    /// For linear barcodes, this is the raw data (which is always ASCII text).
     pub fn data(&self) -> &[u8] {
         &self.data
+    }
+
+    /// Get the raw bytes before encoding conversion, if available.
+    ///
+    /// For QR codes, this returns the original bytes as encoded in the barcode,
+    /// before any text encoding detection or conversion. In mixed-mode QR codes,
+    /// numeric and alphanumeric segments appear as their ASCII representation
+    /// (since those modes encode text, not arbitrary bytes), while byte-mode
+    /// segments are the original uninterpreted bytes.
+    ///
+    /// For SQ codes, this returns the raw bytes before base64 encoding.
+    ///
+    /// Returns `None` for linear barcodes (use [`data`](Self::data) instead,
+    /// which is already raw ASCII).
+    pub fn raw_data(&self) -> Option<&[u8]> {
+        self.raw_data.as_deref()
     }
 
     /// Get the decoded data as a string, if decodable.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -44,11 +44,21 @@ impl ScanOptions {
     }
 }
 
+// Non-wasm helpers
+impl ScanOptions {
+    const DEFAULT_RETRY: bool = true;
+
+    fn retry(&self) -> bool {
+        self.retry_undecoded_regions.unwrap_or(Self::DEFAULT_RETRY)
+    }
+}
+
 /// A decoded barcode/QR code result.
 #[wasm_bindgen]
 pub struct DecodeResult {
     symbol_type: String,
     data: Vec<u8>,
+    text: Option<String>,
 }
 
 #[wasm_bindgen]
@@ -60,24 +70,28 @@ impl DecodeResult {
     }
 
     /// Raw decoded bytes.
+    ///
+    /// For 2D codes (QR, SQ), these are the original bytes as encoded
+    /// in the barcode, before any text encoding or base64 conversion.
     #[wasm_bindgen(getter)]
     pub fn data(&self) -> Vec<u8> {
         self.data.clone()
     }
 
-    /// Decoded data as UTF-8 text, or null if not valid UTF-8.
+    /// Decoded data as text, or null if not decodable as text.
+    ///
+    /// For 2D codes, the text is produced by detecting the encoding (UTF-8,
+    /// Shift-JIS, Windows-1252, etc.) and converting to a UTF-8 string.
+    /// For linear barcodes, the data is always ASCII text.
     #[wasm_bindgen(getter)]
     pub fn text(&self) -> Option<String> {
-        std::str::from_utf8(&self.data).ok().map(|s| s.to_string())
+        self.text.clone()
     }
 }
 
 fn build_scanner(options: Option<ScanOptions>) -> Scanner {
-    let retry = options
-        .and_then(|o| o.retry_undecoded_regions)
-        .unwrap_or(true);
-
-    let config = DecoderConfig::new().retry_undecoded_regions(retry);
+    let options = options.unwrap_or_default();
+    let config = DecoderConfig::new().retry_undecoded_regions(options.retry());
     Scanner::with_config(config)
 }
 
@@ -104,7 +118,8 @@ pub fn scan_grayscale(
         .into_iter()
         .map(|s| DecodeResult {
             symbol_type: s.symbol_type().to_string(),
-            data: s.data().to_vec(),
+            data: s.raw_data().unwrap_or(s.data()).to_vec(),
+            text: s.data_string().map(|t| t.to_string()),
         })
         .collect())
 }

--- a/tests/decode_examples.rs
+++ b/tests/decode_examples.rs
@@ -587,30 +587,25 @@ fn test_rqrr_crash_4_binary() {
     let (symbol_type, data) = result_this.as_ref().unwrap();
     assert_eq!(symbol_type, "QR-Code");
 
-    // Verify it's binary data (contains bytes that would fail UTF-8 decoding as WINDOWS-1252)
-    assert_eq!(data.len(), 2146, "Binary data should be 2146 bytes");
-
-    // Check first few bytes to ensure we're getting the right data
-    // These bytes are from the actual decoded QR code
+    // data() returns text-decoded output (encoding-detected, converted to UTF-8).
+    // The raw QR bytes go through Windows-1252 → UTF-8 conversion, expanding
+    // the 1376 raw bytes to 2146 UTF-8 bytes.
+    assert_eq!(data.len(), 2146, "Text-decoded data should be 2146 bytes");
     assert_eq!(&data[..4], &[0x07, 0xC3, 0x84, 0x18]);
 
     // Verify it contains binary data (bytes outside printable ASCII)
     let has_binary = data.iter().any(|b| !(0x20..0x80).contains(b));
     assert!(has_binary, "Should contain binary data");
 
-    // zbars should produce similar binary data (first bytes should match)
-    // Note: lengths may differ due to padding/encoding differences between implementations
+    // zbars should produce similar text-decoded data (first bytes should match)
     if let Some((zbars_symbol_type, zbars_data)) = result_zbars {
         assert_eq!(zbars_symbol_type, "QR-Code");
         assert_eq!(
             &zbars_data[..4],
             &[0x07, 0xC3, 0x84, 0x18],
-            "zbars should decode to similar binary data"
+            "zbars should decode to similar data"
         );
-        assert!(
-            zbars_data.len() >= 2000,
-            "zbars binary data should be substantial"
-        );
+        assert!(zbars_data.len() >= 2000, "zbars data should be substantial");
     }
 
     // rqrr must match exactly if it succeeds (strict check)
@@ -619,6 +614,97 @@ fn test_rqrr_crash_4_binary() {
             Some(rqrr_result),
             result_this.clone(),
             "rqrr decoded but gave different result"
+        );
+    }
+}
+
+#[test]
+fn test_raw_data_binary_qr() {
+    // raw_data() should return the original bytes before encoding conversion
+    let path = Path::new("examples/rqrr-crash-4.png");
+    if !path.exists() {
+        return;
+    }
+
+    let img = image::open(path).unwrap();
+    let img = downscale_if_needed(img, 1280).to_luma8();
+    let mut scanner = Scanner::new();
+    let mut zbar_image = Image::from_gray(img.as_raw(), img.width(), img.height()).unwrap();
+    let symbols = scanner.scan(&mut zbar_image);
+    let symbol = symbols.first().expect("should decode the QR code");
+
+    let raw = symbol.raw_data().expect("QR codes should have raw_data");
+    let text_decoded = symbol.data();
+
+    // Raw bytes are the pre-encoding-conversion data (1376 bytes)
+    assert_eq!(raw.len(), 1376, "Raw data should be 1376 bytes");
+    assert_eq!(raw[0], 0x07);
+    assert_eq!(
+        raw[1], 0xC4,
+        "Second raw byte should be 0xC4, not the UTF-8 lead byte 0xC3"
+    );
+
+    // Text-decoded data is longer due to Windows-1252 → UTF-8 expansion
+    assert_eq!(text_decoded.len(), 2146);
+    assert!(raw.len() < text_decoded.len());
+
+    // This particular file's raw bytes are detected as Windows-1252 by the
+    // encoding heuristic. If the heuristic changes, the exact text output may
+    // differ — but raw bytes should always be shorter than the text-decoded
+    // output for this binary payload.
+    let (decoded, _enc, _had_errors) = encoding_rs::WINDOWS_1252.decode(raw);
+    assert_eq!(
+        text_decoded,
+        decoded.as_bytes(),
+        "Expected text output to match Windows-1252 decode of raw bytes (if this fails, \
+         the encoding heuristic may have changed)"
+    );
+}
+
+#[test]
+fn test_raw_data_text_qr() {
+    // For ASCII/UTF-8 QR codes, raw_data() and data() should contain the same bytes
+    let path = Path::new("examples/test-qr.png");
+    if !path.exists() {
+        return;
+    }
+
+    let img = image::open(path).unwrap();
+    let img = downscale_if_needed(img, 1280).to_luma8();
+    let mut scanner = Scanner::new();
+    let mut zbar_image = Image::from_gray(img.as_raw(), img.width(), img.height()).unwrap();
+    let symbols = scanner.scan(&mut zbar_image);
+    let symbol = symbols.first().expect("should decode the QR code");
+
+    let raw = symbol.raw_data().expect("QR codes should have raw_data");
+    let text_decoded = symbol.data();
+
+    // For ASCII text, raw bytes and text-decoded bytes are identical
+    assert_eq!(raw, text_decoded);
+    assert_eq!(
+        std::str::from_utf8(raw).unwrap(),
+        "Hello, simplified zbar!\n"
+    );
+}
+
+#[test]
+fn test_raw_data_linear_barcode() {
+    // Linear barcodes don't have raw_data (their data is always ASCII)
+    let path = Path::new("examples/test-ean13.png");
+    if !path.exists() {
+        return;
+    }
+
+    let img = image::open(path).unwrap();
+    let img = downscale_if_needed(img, 1280).to_luma8();
+    let mut scanner = Scanner::new();
+    let mut zbar_image = Image::from_gray(img.as_raw(), img.width(), img.height()).unwrap();
+    let symbols = scanner.scan(&mut zbar_image);
+
+    if let Some(symbol) = symbols.first() {
+        assert!(
+            symbol.raw_data().is_none(),
+            "Linear barcodes should not have raw_data"
         );
     }
 }


### PR DESCRIPTION
Stores both the decoded data and the raw QR code data that's useful in reading binary QR/SQ codes. Changes the `--raw` CLI option to output this raw data instead of the decoded data when available. Since we now store both the raw data and decoded data, there's no reason to keep the `binary` option.