### PR TITLE
fix: enable `retry_undecoded_regions` in zedbarimg for small QR codes

### DIFF
--- a/src/bin/zedbarimg.rs
+++ b/src/bin/zedbarimg.rs
@@ -283,7 +283,8 @@ fn main() {
             cfg = cfg.disable(QrCode);
         }
         cfg
-    };
+    }
+    .retry_undecoded_regions(true);
 
     let mut total_symbols = 0;
 


### PR DESCRIPTION
Small QR code images (< 200px) stopped being detected after the `upscale_small_images` default was replaced by the opt-in `retry_undecoded_regions` feature. This enables it in the CLI.