### PR TITLE
chore: add SessionStart hook to install zbar-tools on Claude Code web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Installs the system zbar library and zbarimg tool. These are needed by:
+#   - tests/decode_examples.rs (compares zedbar's output against zbarimg)
+#   - benches/comparison.rs     (links against the zbar C library)
+#   - cargo clippy --all-targets --all-features (pulls in the bench)
+set -euo pipefail
+
+# Only run in the Claude Code on the web sandbox. Locally the user manages
+# their own system packages.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+if command -v zbarimg >/dev/null 2>&1 && dpkg -s libzbar-dev >/dev/null 2>&1; then
+  # Already installed; nothing to do.
+  exit 0
+fi
+
+# Run the install in the background so session startup isn't blocked.
+echo '{"async": true, "asyncTimeout": 300000}'
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  SUDO="sudo"
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+# `apt-get update` can fail transiently on unrelated third-party repositories
+# in the sandbox image. A failure there shouldn't block installing our packages
+# — apt will use whatever cached index is available.
+$SUDO apt-get update -qq || true
+$SUDO apt-get install -y --no-install-recommends \
+  libzbar-dev \
+  libzbar0 \
+  zbar-tools

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Installs libzbar-dev, libzbar0, and zbar-tools so tests and clippy can run in the web sandbox. These were already installed in GitHub Actions CI (see .github/workflows/ci.yml) but absent from the web sandbox, causing the 18 decode_examples tests that compare zedbar against zbarimg to fail with "zbars failed".

The hook only runs when CLAUDE_CODE_REMOTE=true and is idempotent.

https://claude.ai/code/session_01XWP31krnJXGray2EG5mWhy