### PR TITLE
feat: make `DecoderConfig::new()` start empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ for symbol in symbols {
 }
 ```
 
+### Choosing Symbologies
+
+`DecoderConfig::new()` starts **empty** — opt in to each symbology you need:
+
+```rust
+use zedbar::config::*;
+use zedbar::{DecoderConfig, Scanner};
+
+let config = DecoderConfig::new()
+    .enable(QrCode)
+    .enable(Ean13);
+
+let mut scanner = Scanner::with_config(config);
+```
+
+For exploratory use ("just scan whatever's there"), `DecoderConfig::all()`
+or `Scanner::new()` enables every supported symbology in one call.
+
 ### Advanced Configuration
 
 ```rust
@@ -109,14 +127,17 @@ use zedbar::{DecoderConfig, Scanner};
 let config = DecoderConfig::new()
     .enable(QrCode)
     .enable(Ean13)
-    .set_binary(QrCode, true)          // Preserve binary data in QR codes
-    .set_length_limits(Code39, 4, 20)  // Code39 must be 4-20 chars
+    .set_length_limits(Code39, 4, 20)  // also enables Code39
     .test_inverted(true)               // Try inverted image if no symbols found
     .retry_undecoded_regions(true)     // Crop+upscale small QR codes automatically
     .scan_density(2, 2);               // Scan every 2nd line (faster)
 
 let mut scanner = Scanner::with_config(config);
 ```
+
+The per-symbology setters (`set_length_limits`, `set_checksum`,
+`set_uncertainty`) auto-enable the symbology they target — if you've
+already mentioned a symbology by name, it's on.
 
 ### Small QR Codes in Large Images
 
@@ -129,7 +150,9 @@ use zedbar::config::*;
 use zedbar::{DecoderConfig, Scanner, Image};
 
 // Option 1: Automatic retry (crop + 4x upscale)
-let config = DecoderConfig::new().retry_undecoded_regions(true);
+let config = DecoderConfig::new()
+    .enable(QrCode)
+    .retry_undecoded_regions(true);
 let mut scanner = Scanner::with_config(config);
 let symbols = scanner.scan(&mut img);
 

--- a/examples/scanner_api.rs
+++ b/examples/scanner_api.rs
@@ -9,23 +9,20 @@ use zedbar::{DecoderConfig, Scanner};
 fn main() {
     println!("=== Zedbar Modern Scanner API Examples ===\n");
 
-    // Example 1: Basic usage with default configuration
-    println!("1. Basic scanner with defaults:");
+    // Example 1: Basic usage — scanner with every supported symbology enabled
+    println!("1. Basic scanner (kitchen sink):");
     let _scanner = Scanner::new();
-    println!("   Created scanner with default configuration\n");
+    println!("   Created scanner with every supported symbology\n");
 
-    // Example 2: Custom configuration with specific symbologies
+    // Example 2: Opt-in to specific symbologies
     println!("2. Scanner with custom symbology selection:");
     let config = DecoderConfig::new()
         .enable(Ean13)
         .enable(Ean8)
-        .enable(QrCode)
-        .disable(Code39)
-        .disable(Code128);
+        .enable(QrCode);
 
     let _scanner = Scanner::with_config(config);
-    println!("   Enabled: EAN-13, EAN-8, QR Code");
-    println!("   Disabled: Code39, Code128\n");
+    println!("   Enabled: EAN-13, EAN-8, QR Code\n");
 
     // Example 3: Configure symbology-specific settings
     println!("3. Scanner with symbology-specific settings:");
@@ -40,17 +37,14 @@ fn main() {
 
     // Example 4: Configure scanner for QR codes only
     println!("4. Scanner optimized for QR codes:");
-    let config = DecoderConfig::new()
-        .enable(QrCode)
-        .disable(Ean13) // Only scan QR codes
-        .disable(Code39);
+    let config = DecoderConfig::new().enable(QrCode);
 
     let _scanner = Scanner::with_config(config);
-    println!("   QR Code only, binary mode enabled\n");
+    println!("   QR Code only\n");
 
-    // Example 5: Scanner-level configuration
+    // Example 5: Scanner-level configuration on top of the kitchen sink
     println!("5. Scanner with global scan settings:");
-    let config = DecoderConfig::new()
+    let config = DecoderConfig::all()
         .position_tracking(true) // Track symbol positions
         .test_inverted(true) // Try inverted image if no symbols found
         .scan_density(2, 2); // Scan every 2nd line (faster, less accurate)
@@ -73,7 +67,7 @@ fn main() {
 
     // Example 7: Maximum quality scanning configuration
     println!("7. Maximum quality scanner (optimized for accuracy):");
-    let config = DecoderConfig::new()
+    let config = DecoderConfig::all()
         .scan_density(1, 1) // Scan every line
         .position_tracking(true)
         .test_inverted(true) // Try both normal and inverted

--- a/npm/README.md
+++ b/npm/README.md
@@ -101,6 +101,12 @@ Scans grayscale image data for barcodes and QR codes.
 ### `ScanOptions`
 
 - `retryUndecodedRegions` (`boolean`, default: `true`) - Automatically retry undecoded QR finder regions by cropping and upscaling. Disable to skip the retry and reduce processing time for images that are known to have sufficient resolution.
+- `symbologies` (`string[]`, optional) - Restrict scanning to the listed symbologies. When omitted, every supported symbology is enabled. Names match the `symbolType` field on results — see [Supported Formats](#supported-formats).
+
+```javascript
+// Scan QR codes only
+const results = scanImageBytes(imageBytes, { symbologies: ['QR-Code'] });
+```
 
 ### `DecodeResult`
 

--- a/src/bin/zedbarimg.rs
+++ b/src/bin/zedbarimg.rs
@@ -151,7 +151,7 @@ fn main() {
     // Build configuration based on command-line arguments
     let config = if args.disable_all {
         // Start with all symbologies disabled, then enable selected ones
-        let mut cfg = DecoderConfig::new().disable_all();
+        let mut cfg = DecoderConfig::new();
 
         // Apply enable flags
         if args.enable_ean13 {
@@ -207,8 +207,8 @@ fn main() {
         }
         cfg
     } else {
-        // Start with default configuration (all enabled), then apply changes
-        let mut cfg = DecoderConfig::new();
+        // Start with all symbologies enabled, then apply changes
+        let mut cfg = DecoderConfig::all();
 
         // Apply enable flags (redundant but harmless)
         if args.enable_ean13 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,9 +4,16 @@
 //! invalid configuration combinations. The type system ensures you can only
 //! set configurations that are valid for each symbology.
 //!
+//! # Choosing a starting point
+//!
+//! [`DecoderConfig::new()`] starts empty — you opt in to each symbology you
+//! want. [`DecoderConfig::all()`] starts with every supported symbology
+//! enabled, for callers (CLI tools, exploratory scripts) that want to scan
+//! anything they can find.
+//!
 //! # Examples
 //!
-//! ## Valid Configuration
+//! ## Opt-in (recommended)
 //!
 //! ```
 //! use zedbar::config::*;
@@ -17,6 +24,15 @@
 //!     .enable(Code39)
 //!     .set_length_limits(Code39, 4, 20)   // ✓ Code39 supports variable length
 //!     .position_tracking(true);
+//! ```
+//!
+//! ## Kitchen sink
+//!
+//! ```
+//! use zedbar::config::*;
+//! use zedbar::DecoderConfig;
+//!
+//! let config = DecoderConfig::all();
 //! ```
 //!
 //! ## Type-Safe Compile Errors
@@ -130,9 +146,14 @@ pub trait Symbology: Sized {
 /// This builder uses the type system to ensure only valid configurations
 /// can be set for each symbology type.
 ///
+/// Start from [`DecoderConfig::new()`] (empty — opt in to each symbology
+/// you want) or [`DecoderConfig::all()`] (full kitchen-sink for exploratory
+/// use).
+///
 /// # Example
 /// ```no_run
 /// use zedbar::config::*;
+/// use zedbar::DecoderConfig;
 ///
 /// let config = DecoderConfig::new()
 ///     .enable(Ean13)
@@ -163,21 +184,26 @@ pub struct DecoderConfig {
     pub(crate) retry_undecoded_regions: bool,
 }
 
-impl Default for DecoderConfig {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl DecoderConfig {
-    /// Create a new configuration with sensible defaults
+    /// Create an empty configuration with no symbologies enabled.
     ///
-    /// By default:
-    /// - EAN-13, EAN-8, I25, DataBar, Codabar, Code39, Code93, Code128, QR, SQ are enabled
-    /// - UPC-A, UPC-E, ISBN-10, ISBN-13 can be emitted as variants (not separately enabled)
-    /// - Position tracking is enabled
-    /// - Scan density is 1x1
-    /// - Inverted image testing is disabled
+    /// Opt in to each symbology you want via [`enable`](Self::enable); only
+    /// the decoders you ask for will run.
+    ///
+    /// Global scanner settings (position tracking, scan density, etc.) are
+    /// initialized to sensible defaults; per-symbology config (length limits,
+    /// checksum behavior, uncertainty) for variants like UPC-A, UPC-E,
+    /// ISBN-10, and ISBN-13 is preconfigured so that enabling them produces
+    /// reasonable output.
+    ///
+    /// # Example
+    /// ```
+    /// use zedbar::config::*;
+    /// use zedbar::DecoderConfig;
+    ///
+    /// let config = DecoderConfig::new()
+    ///     .enable(QrCode);
+    /// ```
     pub fn new() -> Self {
         let mut config = Self {
             enabled: HashSet::new(),
@@ -191,11 +217,58 @@ impl DecoderConfig {
             retry_undecoded_regions: false,
         };
 
-        // Enable common symbologies by default
+        // Preconfigure per-symbology defaults so that enabling a symbology
+        // gives reasonable behavior out of the box. These have no effect
+        // until the corresponding symbology is enabled.
+
+        // EAN-13 and EAN-8: emit checksum
+        for sym in [SymbolType::Ean13, SymbolType::Ean8] {
+            config.checksum_flags.insert(sym, (false, true));
+        }
+
+        // UPC-A, UPC-E, ISBN-10, ISBN-13: emit checksum when surfaced as
+        // EAN variants
+        for sym in [
+            SymbolType::Upca,
+            SymbolType::Upce,
+            SymbolType::Isbn10,
+            SymbolType::Isbn13,
+        ] {
+            config.checksum_flags.insert(sym, (false, true));
+        }
+
+        // Default length limits for variable-length symbologies
+        config.length_limits.insert(SymbolType::I25, (6, 256));
+        config.length_limits.insert(SymbolType::Codabar, (4, 256));
+        config.length_limits.insert(SymbolType::Code39, (1, 256));
+
+        // Default uncertainty values
+        config.uncertainty.insert(SymbolType::Codabar, 1);
+
+        config
+    }
+
+    /// Create a configuration with the full set of supported symbologies
+    /// enabled.
+    ///
+    /// Enables EAN-13, EAN-8, I2/5, DataBar, DataBar-Expanded, Codabar,
+    /// Code 39, Code 93, Code 128, QR Code, and SQ Code. UPC-A, UPC-E,
+    /// ISBN-10, and ISBN-13 are *not* enabled — they can be opted in as
+    /// variant labels of EAN-13/EAN-8 via [`enable`](Self::enable).
+    ///
+    /// Prefer [`new()`](Self::new) and explicit [`enable`](Self::enable)
+    /// calls when you know which formats you need.
+    ///
+    /// # Example
+    /// ```
+    /// use zedbar::DecoderConfig;
+    ///
+    /// let config = DecoderConfig::all();
+    /// ```
+    pub fn all() -> Self {
+        let mut config = Self::new();
         config.enabled.insert(SymbolType::Ean13);
         config.enabled.insert(SymbolType::Ean8);
-        // Note: UPC-A, UPC-E, ISBN-10, ISBN-13 are NOT enabled by default
-        // They can be emitted as variants of EAN-13/EAN-8 when detected
         config.enabled.insert(SymbolType::I25);
         config.enabled.insert(SymbolType::Databar);
         config.enabled.insert(SymbolType::DatabarExp);
@@ -205,32 +278,6 @@ impl DecoderConfig {
         config.enabled.insert(SymbolType::Code128);
         config.enabled.insert(SymbolType::QrCode);
         config.enabled.insert(SymbolType::SqCode);
-
-        // Set default checksum behavior for EAN/UPC
-        // EAN-13 and EAN-8 are enabled with emit_check
-        for sym in [SymbolType::Ean13, SymbolType::Ean8] {
-            config.checksum_flags.insert(sym, (false, true)); // don't add, do emit
-        }
-
-        // UPC-A, UPC-E, ISBN variants are not enabled but have emit_check
-        // This allows them to be reported as variants when EAN decoding detects them
-        for sym in [
-            SymbolType::Upca,
-            SymbolType::Upce,
-            SymbolType::Isbn10,
-            SymbolType::Isbn13,
-        ] {
-            config.checksum_flags.insert(sym, (false, true)); // don't add, do emit
-        }
-
-        // Set default length limits for variable-length symbologies
-        config.length_limits.insert(SymbolType::I25, (6, 256));
-        config.length_limits.insert(SymbolType::Codabar, (4, 256));
-        config.length_limits.insert(SymbolType::Code39, (1, 256));
-
-        // Set default uncertainty values
-        config.uncertainty.insert(SymbolType::Codabar, 1);
-
         config
     }
 
@@ -250,23 +297,14 @@ impl DecoderConfig {
         self
     }
 
-    /// Disable all symbologies
+    /// Enable a symbology by its runtime [`SymbolType`].
     ///
-    /// Useful when you want to start with a clean slate and only enable
-    /// specific symbologies.
-    ///
-    /// # Example
-    /// ```
-    /// use zedbar::config::*;
-    /// use zedbar::DecoderConfig;
-    ///
-    /// let config = DecoderConfig::new()
-    ///     .disable_all()
-    ///     .enable(QrCode)
-    ///     .enable(Code39);
-    /// ```
-    pub fn disable_all(mut self) -> Self {
-        self.enabled.clear();
+    /// Prefer [`enable`](Self::enable) when the symbology is known at
+    /// compile time — it carries the [`SupportsEnable`] capability bound.
+    /// This runtime variant is for callers parsing config from strings,
+    /// CLI flags, or other dynamic sources.
+    pub fn enable_type(mut self, sym: SymbolType) -> Self {
+        self.enabled.insert(sym);
         self
     }
 
@@ -275,7 +313,8 @@ impl DecoderConfig {
         self.enabled.contains(&sym)
     }
 
-    /// Configure checksum behavior for a symbology
+    /// Configure checksum behavior for a symbology, enabling it if not
+    /// already enabled.
     ///
     /// # Arguments
     /// * `add_check` - Validate checksum during decoding
@@ -286,11 +325,13 @@ impl DecoderConfig {
         add_check: bool,
         emit_check: bool,
     ) -> Self {
+        self.enabled.insert(S::TYPE);
         self.checksum_flags.insert(S::TYPE, (add_check, emit_check));
         self
     }
 
-    /// Set minimum and maximum length limits
+    /// Set minimum and maximum length limits, enabling the symbology if not
+    /// already enabled.
     ///
     /// Only valid for variable-length symbologies like Code39, Code128, etc.
     pub fn set_length_limits<S: Symbology + SupportsLengthLimits>(
@@ -301,11 +342,13 @@ impl DecoderConfig {
     ) -> Self {
         assert!(min <= max, "min length must be <= max length");
         assert!(max <= 256, "max length must be <= 256");
+        self.enabled.insert(S::TYPE);
         self.length_limits.insert(S::TYPE, (min, max));
         self
     }
 
-    /// Set uncertainty threshold for edge detection
+    /// Set uncertainty threshold for edge detection, enabling the symbology
+    /// if not already enabled.
     ///
     /// Higher values are more tolerant of poor quality images but may
     /// produce more false positives.
@@ -314,6 +357,7 @@ impl DecoderConfig {
         _: S,
         threshold: u32,
     ) -> Self {
+        self.enabled.insert(S::TYPE);
         self.uncertainty.insert(S::TYPE, threshold);
         self
     }
@@ -387,10 +431,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_default_config() {
+    fn test_new_is_empty() {
         let config = DecoderConfig::new();
-        assert!(config.is_enabled(SymbolType::Ean13));
-        assert!(config.is_enabled(SymbolType::Code39));
+        for sym in SymbolType::ALL.iter() {
+            assert!(
+                !config.is_enabled(*sym),
+                "{sym:?} should be disabled in DecoderConfig::new()",
+            );
+        }
         assert!(config.position_tracking);
         assert!(!config.test_inverted);
         assert_eq!(config.x_density, 1);
@@ -398,11 +446,44 @@ mod tests {
     }
 
     #[test]
+    fn test_all_enables_kitchen_sink() {
+        let config = DecoderConfig::all();
+        for sym in [
+            SymbolType::Ean13,
+            SymbolType::Ean8,
+            SymbolType::I25,
+            SymbolType::Databar,
+            SymbolType::DatabarExp,
+            SymbolType::Codabar,
+            SymbolType::Code39,
+            SymbolType::Code93,
+            SymbolType::Code128,
+            SymbolType::QrCode,
+            SymbolType::SqCode,
+        ] {
+            assert!(
+                config.is_enabled(sym),
+                "{sym:?} should be enabled in ::all()"
+            );
+        }
+        // UPC/ISBN variants stay opt-in.
+        for sym in [
+            SymbolType::Upca,
+            SymbolType::Upce,
+            SymbolType::Isbn10,
+            SymbolType::Isbn13,
+        ] {
+            assert!(!config.is_enabled(sym));
+        }
+    }
+
+    #[test]
     fn test_builder_pattern() {
-        let config = DecoderConfig::new()
+        let config = DecoderConfig::all()
             .enable(Ean13)
             .disable(Code39)
-            .set_checksum(Code39, true, false)
+            .set_checksum(Code39, true, false) // re-enables Code39
+            .disable(Code39)
             .position_tracking(false)
             .scan_density(2, 2);
 
@@ -411,6 +492,17 @@ mod tests {
         assert!(!config.position_tracking);
         assert_eq!(config.x_density, 2);
         assert_eq!(config.y_density, 2);
+    }
+
+    #[test]
+    fn test_setters_auto_enable() {
+        let config = DecoderConfig::new()
+            .set_length_limits(Code39, 4, 20)
+            .set_checksum(Codabar, true, false)
+            .set_uncertainty(QrCode, 2);
+        assert!(config.is_enabled(SymbolType::Code39));
+        assert!(config.is_enabled(SymbolType::Codabar));
+        assert!(config.is_enabled(SymbolType::QrCode));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -204,6 +204,10 @@ impl DecoderConfig {
     /// let config = DecoderConfig::new()
     ///     .enable(QrCode);
     /// ```
+    #[allow(
+        clippy::new_without_default,
+        reason = "`::new()` intentionally omits all symbologies, but that is unergonomic as a `Default::default` implementation"
+    )]
     pub fn new() -> Self {
         let mut config = Self {
             enabled: HashSet::new(),

--- a/src/config/internal.rs
+++ b/src/config/internal.rs
@@ -81,8 +81,11 @@ impl Default for ScannerConfig {
 }
 
 impl Default for DecoderState {
+    /// Internal default: kitchen-sink configuration. Used as the
+    /// `..Default::default()` placeholder in [`ImageScanner::with_config`];
+    /// the `config` field is always overwritten before the scanner is used.
     fn default() -> Self {
-        (&DecoderConfig::new()).into()
+        (&DecoderConfig::all()).into()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,9 +402,9 @@ mod tests {
 
         let mut img = Image::from_gray(data, width, height).expect("Failed to create zedbar image");
 
-        // Create scanner with UPC-A explicitly enabled
+        // UPC-A surfaces as a label on the EAN-13 decoder; both must be enabled.
         use crate::config::*;
-        let config = DecoderConfig::new().enable(Upca);
+        let config = DecoderConfig::new().enable(Ean13).enable(Upca);
         let mut scanner = Scanner::with_config(config);
 
         let symbols = scanner.scan(&mut img);
@@ -749,7 +749,9 @@ https://zh.qr-code-generator.com
             let mut zedbar_img = Image::from_gray(gray.as_raw(), width, height)
                 .expect("Failed to create zedbar image");
 
-            let config = DecoderConfig::new().retry_undecoded_regions(true);
+            let config = DecoderConfig::new()
+                .enable(QrCode)
+                .retry_undecoded_regions(true);
             let mut scanner = Scanner::with_config(config);
             let result = scanner.scan(&mut zedbar_img);
 
@@ -788,7 +790,9 @@ https://zh.qr-code-generator.com
         let mut zedbar_img =
             Image::from_gray(gray.as_raw(), width, height).expect("Failed to create zedbar image");
 
-        let config = DecoderConfig::new().retry_undecoded_regions(true);
+        let config = DecoderConfig::new()
+            .enable(QrCode)
+            .retry_undecoded_regions(true);
         let mut scanner = Scanner::with_config(config);
         let result = scanner.scan(&mut zedbar_img);
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -8,11 +8,11 @@
 //! ```no_run
 //! use zedbar::{Image, Scanner};
 //!
-//! // Create a scanner with default settings
+//! // Create a scanner with every supported symbology enabled.
 //! let mut scanner = Scanner::new();
 //!
-//! // Or with custom configuration
-//! use zedbar::config::*;
+//! // Or build a scanner with only the symbologies you need.
+//! use zedbar::{DecoderConfig, config::*};
 //! let config = DecoderConfig::new()
 //!     .enable(QrCode)
 //!     .enable(Ean13);
@@ -177,14 +177,15 @@ pub struct Scanner {
 }
 
 impl Scanner {
-    /// Create a new image scanner with default configuration
+    /// Create a new image scanner with every supported symbology enabled.
     ///
-    /// For more control over the configuration, use [`Scanner::with_config()`].
+    /// Equivalent to `Scanner::with_config(DecoderConfig::all())`. Convenient
+    /// for exploratory use; for production use, prefer
+    /// [`Scanner::with_config()`] with a
+    /// [`DecoderConfig::new()`](DecoderConfig::new) that opts into only the
+    /// symbologies you actually need.
     pub fn new() -> Self {
-        Self {
-            scanner: ImageScanner::default(),
-            retry_undecoded_regions: false,
-        }
+        Self::with_config(DecoderConfig::all())
     }
 
     /// Create a new image scanner with custom configuration
@@ -310,11 +311,5 @@ impl Scanner {
         }
 
         ScanResult::new(symbols, unresolved)
-    }
-}
-
-impl Default for Scanner {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -313,3 +313,9 @@ impl Scanner {
         ScanResult::new(symbols, unresolved)
     }
 }
+
+impl Default for Scanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -242,3 +242,30 @@ impl From<i32> for SymbolType {
         }
     }
 }
+
+/// Returned when a string does not match any [`SymbolType`] display name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseSymbolTypeError(pub String);
+
+impl Display for ParseSymbolTypeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unknown symbology: {:?}", self.0)
+    }
+}
+
+impl std::error::Error for ParseSymbolTypeError {}
+
+impl std::str::FromStr for SymbolType {
+    type Err = ParseSymbolTypeError;
+
+    /// Parse a symbology by its [`Display`] name (e.g. `"QR-Code"`,
+    /// `"EAN-13"`, `"CODE-128"`). Recognises every variant in
+    /// [`SymbolType::ALL`].
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|sym| sym.to_string() == s)
+            .ok_or_else(|| ParseSymbolTypeError(s.to_string()))
+    }
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -2,6 +2,7 @@
 
 use wasm_bindgen::prelude::*;
 
+use crate::SymbolType;
 use crate::config::DecoderConfig;
 use crate::image::Image;
 use crate::scanner::Scanner;
@@ -14,16 +15,20 @@ use image;
 /// All fields are optional and default to sensible values when omitted.
 ///
 /// ```js
-/// // Use defaults (retry enabled):
+/// // Use defaults (every supported symbology, retry enabled):
 /// const results = scanGrayscale(data, width, height);
 ///
 /// // Disable automatic retry of small QR codes:
 /// const results = scanGrayscale(data, width, height, { retryUndecodedRegions: false });
+///
+/// // Restrict to QR codes only:
+/// const results = scanGrayscale(data, width, height, { symbologies: ["QR-Code"] });
 /// ```
 #[wasm_bindgen]
 #[derive(Default)]
 pub struct ScanOptions {
     retry_undecoded_regions: Option<bool>,
+    symbologies: Option<Vec<String>>,
 }
 
 #[wasm_bindgen]
@@ -31,9 +36,7 @@ impl ScanOptions {
     /// Create a new options object with defaults.
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
-        Self {
-            retry_undecoded_regions: None,
-        }
+        Self::default()
     }
 
     /// Whether to automatically retry undecoded QR finder regions by
@@ -41,6 +44,19 @@ impl ScanOptions {
     #[wasm_bindgen(setter, js_name = "retryUndecodedRegions")]
     pub fn set_retry_undecoded_regions(&mut self, value: bool) {
         self.retry_undecoded_regions = Some(value);
+    }
+
+    /// Restrict scanning to the listed symbologies. When omitted, every
+    /// supported symbology is enabled.
+    ///
+    /// Names match the `symbolType` field on decode results: `"QR-Code"`,
+    /// `"SQ-Code"`, `"EAN-13"`, `"EAN-8"`, `"EAN-2"`, `"EAN-5"`,
+    /// `"UPC-A"`, `"UPC-E"`, `"ISBN-10"`, `"ISBN-13"`, `"I2/5"`,
+    /// `"DataBar"`, `"DataBar-Exp"`, `"Codabar"`, `"CODE-39"`,
+    /// `"CODE-93"`, `"CODE-128"`.
+    #[wasm_bindgen(setter, js_name = "symbologies")]
+    pub fn set_symbologies(&mut self, value: Vec<String>) {
+        self.symbologies = Some(value);
     }
 }
 
@@ -89,10 +105,25 @@ impl DecodeResult {
     }
 }
 
-fn build_scanner(options: Option<ScanOptions>) -> Scanner {
+fn build_scanner(options: Option<ScanOptions>) -> Result<Scanner, JsValue> {
     let options = options.unwrap_or_default();
-    let config = DecoderConfig::new().retry_undecoded_regions(options.retry());
-    Scanner::with_config(config)
+    let mut config = match &options.symbologies {
+        Some(syms) => {
+            let mut cfg = DecoderConfig::new();
+            for name in syms {
+                let sym: SymbolType =
+                    name.parse()
+                        .map_err(|e: crate::symbol::ParseSymbolTypeError| {
+                            JsValue::from_str(&e.to_string())
+                        })?;
+                cfg = cfg.enable_type(sym);
+            }
+            cfg
+        }
+        None => DecoderConfig::all(),
+    };
+    config = config.retry_undecoded_regions(options.retry());
+    Ok(Scanner::with_config(config))
 }
 
 /// Scan grayscale image data for barcodes and QR codes.
@@ -111,7 +142,7 @@ pub fn scan_grayscale(
     let mut image =
         Image::from_gray(data, width, height).map_err(|e| JsValue::from_str(&format!("{e:?}")))?;
 
-    let mut scanner = build_scanner(options);
+    let mut scanner = build_scanner(options)?;
     let symbols = scanner.scan(&mut image);
 
     Ok(symbols

--- a/tests/decode_examples.rs
+++ b/tests/decode_examples.rs
@@ -743,7 +743,8 @@ fn test_nine_barcodes() {
     let img = image::open(path).expect("failed to open nine-barcodes.png");
     let img = downscale_if_needed(img, 1280).to_luma8();
 
-    let config = DecoderConfig::new().enable(Upca).enable(Upce);
+    // Kitchen sink + opt in to UPC-A/UPC-E variant labeling on top of EAN.
+    let config = DecoderConfig::all().enable(Upca).enable(Upce);
     let mut scanner = Scanner::with_config(config);
     let mut zbar_image = Image::from_gray(img.as_raw(), img.width(), img.height()).unwrap();
     let symbols = scanner.scan(&mut zbar_image);


### PR DESCRIPTION
Fixes #47 

This encourages better production usage by making it more likely that consumers will selectively enable only the symbologies they actually need. This is a BREAKING CHANGE due to the change in behavior, but since we're pre-v1.0 now's the time to make such changes. The high-level `Scanner` Rust API, the JS/WASM API, and the CLIs all retain their existing behavior.