### PR TITLE
feat: expose symbol position points and bounding rectangle

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,31 @@ for symbol in symbols {
 }
 ```
 
+### Locating a Symbol in the Image
+
+Each [`Symbol`] records the image-coordinate points where it was detected,
+which lets you draw a box around the decode or crop the source image.
+
+```rust
+for symbol in symbols {
+    // QR codes record the four corners of their bounding rectangle;
+    // linear barcodes record per-scan touchpoints.
+    for point in symbol.points() {
+        println!("  point at ({}, {})", point.x, point.y);
+    }
+
+    // Or, the axis-aligned bounding box of all those points:
+    if let Some(b) = symbol.bounds() {
+        println!("  bounds: {}×{} at ({}, {})", b.width, b.height, b.x, b.y);
+    }
+}
+```
+
+`bounds()` returns the AABB of `points()`, with `width` and `height`
+reported as `max - min` of the recorded points (the extent between the
+outermost points), not as a pixel count. Both return empty / `None` for
+symbols that did not record any points.
+
 ### Choosing Symbologies
 
 `DecoderConfig::new()` starts **empty** — opt in to each symbology you need:

--- a/README.md
+++ b/README.md
@@ -15,20 +15,16 @@ This is a port of the ZBar library to Rust, providing barcode detection and deco
 
 ## Installation
 
-Add to your `Cargo.toml`:
-
-```toml
-[dependencies]
-zedbar = "0.2"
+```bash
+cargo add zedbar
 ```
 
 ### Cargo Features
 
 By default, all symbologies are enabled. You can selectively enable only the ones you need to reduce compile time and binary size:
 
-```toml
-[dependencies]
-zedbar = { version = "0.2", default-features = false, features = ["qrcode", "ean"] }
+```bash
+cargo add zedbar --no-default-features --features qrcode,ean
 ```
 
 #### Symbology Features
@@ -63,16 +59,14 @@ default = ["qrcode", "sqcode", "ean", "code128", "code39", "code93", "codabar", 
 
 For the absolute minimal build with zero external dependencies (1D barcodes only):
 
-```toml
-[dependencies]
-zedbar = { version = "0.2", default-features = false, features = ["ean"] }
+```bash
+cargo add zedbar --no-default-features --features ean
 ```
 
 For QR codes only (with necessary dependencies):
 
-```toml
-[dependencies]
-zedbar = { version = "0.2", default-features = false, features = ["qrcode"] }
+```bash
+cargo add zedbar --no-default-features --features qrcode
 ```
 
 Note: Disabling a feature at compile-time means that symbology will not be compiled into the binary at all, which is different from disabling it via runtime configuration.

--- a/demo/app.js
+++ b/demo/app.js
@@ -202,6 +202,7 @@ function scanBitmap(bitmap) {
     const t0 = performance.now();
     const results = scanGrayscale(gray, width, height);
     const elapsed = performance.now() - t0;
+    drawSymbolOverlay(ctx, results);
     displayResults(results, elapsed);
     showPermalink();
   } catch (e) {
@@ -209,6 +210,67 @@ function scanBitmap(bitmap) {
   } finally {
     dropZone.classList.remove("loading");
   }
+}
+
+function colorForSymbolType(symbolType) {
+  switch (symbolType) {
+    case "QR-Code":
+      return "#22c55e";
+    case "SQ-Code":
+      return "#3b82f6";
+    default:
+      return "#f59e0b";
+  }
+}
+
+// Sort 2D points clockwise around their centroid so a polygon connecting
+// them in order forms the convex outline of the symbol. Without this the
+// 4 QR corner points (recorded in a non-traversal order) would cross
+// themselves when stroked as a polygon.
+function pointsAroundCentroid(points) {
+  if (points.length <= 2) return points;
+  let cx = 0;
+  let cy = 0;
+  for (const p of points) {
+    cx += p.x;
+    cy += p.y;
+  }
+  cx /= points.length;
+  cy /= points.length;
+  return [...points].sort(
+    (a, b) => Math.atan2(a.y - cy, a.x - cx) - Math.atan2(b.y - cy, b.x - cx),
+  );
+}
+
+// Draws an outline of each detected symbol on top of the source image:
+// a polygon for symbols that recorded multiple points (QR corners, scan
+// touchpoints) and a bounding rectangle as a fallback. Drawn in image
+// coordinates so it scales with the canvas's CSS sizing.
+function drawSymbolOverlay(ctx, results) {
+  if (!results || results.length === 0) return;
+  const stroke = Math.max(2, Math.min(ctx.canvas.width, ctx.canvas.height) / 300);
+  ctx.save();
+  ctx.lineWidth = stroke;
+  ctx.lineJoin = "round";
+  ctx.shadowColor = "rgba(0, 0, 0, 0.6)";
+  ctx.shadowBlur = stroke * 1.5;
+  for (const result of results) {
+    ctx.strokeStyle = colorForSymbolType(result.symbolType);
+    const points = pointsAroundCentroid(result.points || []);
+    if (points.length >= 3) {
+      ctx.beginPath();
+      ctx.moveTo(points[0].x, points[0].y);
+      for (let i = 1; i < points.length; i++) {
+        ctx.lineTo(points[i].x, points[i].y);
+      }
+      ctx.closePath();
+      ctx.stroke();
+    } else if (result.bounds) {
+      const { x, y, width, height } = result.bounds;
+      ctx.strokeRect(x, y, width, height);
+    }
+  }
+  ctx.restore();
 }
 
 function formatTypeLabel(symbolType, count) {

--- a/demo/build-html.mjs
+++ b/demo/build-html.mjs
@@ -10,28 +10,14 @@ import { dirname, join } from 'node:path';
 import { createHighlighter } from 'shiki';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const projectDir = join(__dirname, '..');
 
 async function main() {
-  // Read version from Cargo.toml
-  const cargoToml = await readFile(join(projectDir, 'Cargo.toml'), 'utf-8');
-  const versionMatch = cargoToml.match(/^version\s*=\s*"([^"]+)"/m);
-  if (!versionMatch) {
-    throw new Error('Could not find version in Cargo.toml');
-  }
-  const fullVersion = versionMatch[1];
-  // Use major.minor for the dependency specifier (e.g. "0.2.1" -> "0.2")
-  const depVersion = fullVersion.split('.').slice(0, 2).join('.');
-
   const highlighter = await createHighlighter({
     themes: ['github-light', 'one-dark-pro'],
-    langs: ['rust', 'javascript', 'bash', 'toml'],
+    langs: ['rust', 'javascript', 'bash'],
   });
 
   let html = await readFile(join(__dirname, 'index.src.html'), 'utf-8');
-
-  // Replace version placeholder
-  html = html.replace(/\{\{ZEDBAR_VERSION\}\}/g, depVersion);
 
   // Find all <code data-lang="...">...</code> blocks and highlight them
   const codeBlockRegex = /<code data-lang="(\w+)">([\s\S]*?)<\/code>/g;

--- a/demo/index.html
+++ b/demo/index.html
@@ -134,9 +134,8 @@
 <span class="line"><span style="color:#6F42C1;--shiki-dark:#61AFEF">zedbarimg</span><span style="color:#005CC5;--shiki-dark:#D19A66"> --quiet</span><span style="color:#032F62;--shiki-dark:#98C379"> barcode.jpg</span></span></code></pre>
 
         <h3>Library Usage</h3>
-        <p>Add zedbar to your <code>Cargo.toml</code>:</p>
-        <pre><code><span class="line"><span style="color:#24292E;--shiki-dark:#ABB2BF">[</span><span style="color:#6F42C1;--shiki-dark:#61AFEF">dependencies</span><span style="color:#24292E;--shiki-dark:#ABB2BF">]</span></span>
-<span class="line"><span style="color:#24292E;--shiki-dark:#E06C75">zedbar</span><span style="color:#24292E;--shiki-dark:#ABB2BF"> = </span><span style="color:#032F62;--shiki-dark:#98C379">"0.2"</span></span></code></pre>
+        <p>Add zedbar to your project:</p>
+        <pre><code><span class="line"><span style="color:#6F42C1;--shiki-dark:#61AFEF">cargo</span><span style="color:#032F62;--shiki-dark:#98C379"> add</span><span style="color:#032F62;--shiki-dark:#98C379"> zedbar</span></span></code></pre>
         <pre><code><span class="line"><span style="color:#D73A49;--shiki-dark:#C678DD">use</span><span style="color:#6F42C1;--shiki-dark:#E5C07B"> zedbar</span><span style="color:#D73A49;--shiki-dark:#ABB2BF">::</span><span style="color:#24292E;--shiki-dark:#ABB2BF">{</span><span style="color:#6F42C1;--shiki-dark:#E5C07B">Scanner</span><span style="color:#24292E;--shiki-dark:#ABB2BF">, </span><span style="color:#6F42C1;--shiki-dark:#E5C07B">Image</span><span style="color:#24292E;--shiki-dark:#ABB2BF">, </span><span style="color:#6F42C1;--shiki-dark:#E5C07B">DecoderConfig</span><span style="color:#24292E;--shiki-dark:#ABB2BF">};</span></span>
 <span class="line"><span style="color:#D73A49;--shiki-dark:#C678DD">use</span><span style="color:#6F42C1;--shiki-dark:#E5C07B"> zedbar</span><span style="color:#D73A49;--shiki-dark:#ABB2BF">::</span><span style="color:#6F42C1;--shiki-dark:#E5C07B">config</span><span style="color:#D73A49;--shiki-dark:#ABB2BF">::</span><span style="color:#24292E;--shiki-dark:#ABB2BF">{</span><span style="color:#6F42C1;--shiki-dark:#E5C07B">QrCode</span><span style="color:#24292E;--shiki-dark:#ABB2BF">, </span><span style="color:#6F42C1;--shiki-dark:#E5C07B">Ean13</span><span style="color:#24292E;--shiki-dark:#ABB2BF">};</span></span>
 <span class="line"></span>

--- a/demo/index.src.html
+++ b/demo/index.src.html
@@ -128,9 +128,8 @@
 zedbarimg --quiet barcode.jpg</code></pre>
 
         <h3>Library Usage</h3>
-        <p>Add zedbar to your <code>Cargo.toml</code>:</p>
-        <pre><code data-lang="toml">[dependencies]
-zedbar = "{{ZEDBAR_VERSION}}"</code></pre>
+        <p>Add zedbar to your project:</p>
+        <pre><code data-lang="bash">cargo add zedbar</code></pre>
         <pre><code data-lang="rust">use zedbar::{Scanner, Image, DecoderConfig};
 use zedbar::config::{QrCode, Ean13};
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -113,6 +113,30 @@ const results = scanImageBytes(imageBytes, { symbologies: ['QR-Code'] });
 - `symbolType` (`string`) - Barcode format (e.g., `"QR-Code"`, `"EAN-13"`)
 - `data` (`Uint8Array`) - Raw decoded bytes
 - `text` (`string | undefined`) - Decoded data as UTF-8 string, or `undefined` if not valid UTF-8
+- `points` (`Point[]`) - Position points in image coordinates. For QR codes, the four corners of the QR's bounding rectangle (in implementation-defined order). For linear barcodes, one or more touchpoints accumulated as the symbol was scanned. Empty if no points were recorded.
+- `bounds` (`Bounds | undefined`) - Axis-aligned bounding rectangle of `points`, or `undefined` if no points were recorded.
+
+### `Point`
+
+- `x` (`number`)
+- `y` (`number`)
+
+### `Bounds`
+
+- `x`, `y` (`number`) - Top-left corner in image coordinates.
+- `width`, `height` (`number`) - Reported as `max - min` of the recorded points (the horizontal and vertical extent between the outermost points), not as a pixel count.
+
+```javascript
+for (const result of scanImageBytes(imageBytes)) {
+  for (const { x, y } of result.points) {
+    console.log(`  point at (${x}, ${y})`);
+  }
+  if (result.bounds) {
+    const { x, y, width, height } = result.bounds;
+    console.log(`  bounds: ${width}×${height} at (${x}, ${y})`);
+  }
+}
+```
 
 ## Supported Formats
 

--- a/npm/test.mjs
+++ b/npm/test.mjs
@@ -49,3 +49,33 @@ for (const [filename, expectedType, expectedData] of testCases) {
   });
 
 }
+
+test('QR code exposes points and bounds', async () => {
+  const imageBytes = await readFile(join(examplesDir, 'test-qr.png'));
+  const results = zedbar.scanImageBytes(imageBytes);
+  const qr = results.find((r) => r.symbolType === 'QR-Code');
+  assert(qr, 'expected a QR-Code result');
+
+  // QR codes record their four corner points.
+  assert(Array.isArray(qr.points), 'points should be an array');
+  assert.equal(qr.points.length, 4);
+  for (const p of qr.points) {
+    assert.equal(typeof p.x, 'number');
+    assert.equal(typeof p.y, 'number');
+  }
+
+  const bounds = qr.bounds;
+  assert(bounds, 'QR-Code result should have bounds');
+
+  // Bounds should be the AABB of the points.
+  const xs = qr.points.map((p) => p.x);
+  const ys = qr.points.map((p) => p.y);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  assert.equal(bounds.x, minX);
+  assert.equal(bounds.y, minY);
+  assert.equal(bounds.width, maxX - minX);
+  assert.equal(bounds.height, maxY - minY);
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub use config::DecoderConfig;
 pub use error::{Error, Result};
 pub use image::Image;
 pub use scanner::{FinderRegion, ScanResult, Scanner};
-pub use symbol::{Orientation, SymbolType};
+pub use symbol::{Bounds, Orientation, Point, SymbolType};
 
 #[cfg(all(test, feature = "qrcode"))]
 mod proptest_qr;
@@ -173,6 +173,50 @@ mod tests {
             "✓ zedbar and rqrr agree on {} symbols",
             zedbar_results.len()
         );
+    }
+
+    #[test]
+    fn test_qr_symbol_bounds_from_real_scan() {
+        let img = ::image::ImageReader::open("examples/test-qr.png")
+            .expect("Failed to open image")
+            .decode()
+            .expect("Failed to decode image");
+        let gray = img.to_luma8();
+        let (width, height) = gray.dimensions();
+        let mut zedbar_img =
+            Image::from_gray(gray.as_raw(), width, height).expect("Failed to create zedbar image");
+        let mut scanner = Scanner::new();
+        let symbols = scanner.scan(&mut zedbar_img);
+        let symbol = symbols
+            .symbols()
+            .iter()
+            .find(|s| s.symbol_type() == SymbolType::QrCode)
+            .expect("Expected at least one QR symbol");
+
+        // QR codes record the 4 corners of their bounding rectangle.
+        assert_eq!(symbol.points().len(), 4);
+
+        let bounds = symbol.bounds().expect("QR symbol should have bounds");
+
+        // Bounds should sit inside the source image and have non-zero extent.
+        assert!(bounds.x >= 0);
+        assert!(bounds.y >= 0);
+        assert!(bounds.width > 0);
+        assert!(bounds.height > 0);
+        assert!(bounds.x as u32 + bounds.width <= width);
+        assert!(bounds.y as u32 + bounds.height <= height);
+
+        // Bounds should be the AABB of the recorded points.
+        let xs = symbol.points().iter().map(|p| p.x);
+        let ys = symbol.points().iter().map(|p| p.y);
+        let min_x = xs.clone().min().expect("at least one point");
+        let max_x = xs.max().expect("at least one point");
+        let min_y = ys.clone().min().expect("at least one point");
+        let max_y = ys.max().expect("at least one point");
+        assert_eq!(bounds.x, min_x);
+        assert_eq!(bounds.y, min_y);
+        assert_eq!(bounds.width, (max_x - min_x) as u32);
+        assert_eq!(bounds.height, (max_y - min_y) as u32);
     }
 
     #[test]

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -290,8 +290,8 @@ impl Scanner {
                 let half = scale as i32 / 2;
                 for sym in &mut retry_symbols {
                     for pt in &mut sym.pts {
-                        pt[0] = (pt[0] + half) / scale as i32 + cx as i32;
-                        pt[1] = (pt[1] + half) / scale as i32 + cy as i32;
+                        pt.x = (pt.x + half) / scale as i32 + cx as i32;
+                        pt.y = (pt.y + half) / scale as i32 + cy as i32;
                     }
                 }
                 for sym in retry_symbols {

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -24,12 +24,7 @@
 //! }
 //! ```
 
-#[cfg(feature = "qrcode")]
-use crate::qrcode::qrdec::qr_point;
 use std::{fmt::Display, str::from_utf8};
-
-#[cfg(not(feature = "qrcode"))]
-pub(crate) type qr_point = [i32; 2];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
 pub enum Orientation {
@@ -41,13 +36,38 @@ pub enum Orientation {
     Left,
 }
 
+/// A 2D pixel coordinate in image space.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Point {
+    pub x: i32,
+    pub y: i32,
+}
+
+impl Point {
+    pub const fn new(x: i32, y: i32) -> Self {
+        Self { x, y }
+    }
+}
+
+impl From<[i32; 2]> for Point {
+    fn from([x, y]: [i32; 2]) -> Self {
+        Self { x, y }
+    }
+}
+
+impl From<Point> for [i32; 2] {
+    fn from(p: Point) -> Self {
+        [p.x, p.y]
+    }
+}
+
 #[derive(Default, Clone)]
 pub struct Symbol {
     symbol_type: SymbolType,
     pub(crate) modifiers: u32,
     pub(crate) data: Vec<u8>,
     pub(crate) raw_data: Option<Vec<u8>>,
-    pub(crate) pts: Vec<qr_point>,
+    pub(crate) pts: Vec<Point>,
     pub(crate) orientation: Orientation,
     pub(crate) components: Vec<Symbol>,
     pub(crate) quality: i32,
@@ -76,7 +96,7 @@ impl Symbol {
     }
 
     pub(crate) fn add_point(&mut self, x: i32, y: i32) {
-        self.pts.push([x, y]);
+        self.pts.push(Point::new(x, y));
     }
 }
 
@@ -129,6 +149,68 @@ impl Symbol {
     pub fn components(&self) -> &[Symbol] {
         &self.components
     }
+
+    /// Get the recorded position points of this symbol in image coordinates.
+    ///
+    /// For QR codes, this is the four corner points of the QR's bounding
+    /// rectangle (in an implementation-defined order). For linear barcodes,
+    /// this is one or more touchpoints accumulated as the symbol was
+    /// scanned, suitable for approximating the symbol's extent.
+    ///
+    /// Returns an empty slice when no points were recorded — for example,
+    /// when position tracking is disabled for linear barcodes, or when the
+    /// symbol came from a code path that does not populate points.
+    pub fn points(&self) -> &[Point] {
+        &self.pts
+    }
+
+    /// Get the axis-aligned bounding rectangle of this symbol in image
+    /// coordinates, computed from [`points`](Self::points).
+    ///
+    /// `width` and `height` are reported as `max - min` of the recorded
+    /// points (i.e. the horizontal and vertical extent between the
+    /// outermost points), not as a pixel count.
+    ///
+    /// Returns `None` when no points were recorded.
+    pub fn bounds(&self) -> Option<Bounds> {
+        let mut iter = self.pts.iter().copied();
+        let Point { x: x0, y: y0 } = iter.next()?;
+        let (mut min_x, mut max_x) = (x0, x0);
+        let (mut min_y, mut max_y) = (y0, y0);
+        for Point { x, y } in iter {
+            if x < min_x {
+                min_x = x;
+            } else if x > max_x {
+                max_x = x;
+            }
+            if y < min_y {
+                min_y = y;
+            } else if y > max_y {
+                max_y = y;
+            }
+        }
+        let width = (max_x as i64 - min_x as i64).max(0).min(u32::MAX as i64) as u32;
+        let height = (max_y as i64 - min_y as i64).max(0).min(u32::MAX as i64) as u32;
+        Some(Bounds {
+            x: min_x,
+            y: min_y,
+            width,
+            height,
+        })
+    }
+}
+
+/// Axis-aligned bounding rectangle of a [`Symbol`] in image coordinates.
+///
+/// `x` and `y` are the top-left corner. `width` and `height` are the
+/// horizontal and vertical extent of the symbol's recorded points, computed
+/// as `max - min` (so a single recorded point yields `width == height == 0`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Bounds {
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
@@ -267,5 +349,74 @@ impl std::str::FromStr for SymbolType {
             .copied()
             .find(|sym| sym.to_string() == s)
             .ok_or_else(|| ParseSymbolTypeError(s.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_points_empty_when_no_points_recorded() {
+        let sym = Symbol::new(SymbolType::QrCode);
+        assert!(sym.points().is_empty());
+    }
+
+    #[test]
+    fn test_bounds_returns_none_when_no_points_recorded() {
+        let sym = Symbol::new(SymbolType::QrCode);
+        assert_eq!(sym.bounds(), None);
+    }
+
+    #[test]
+    fn test_bounds_with_single_point_has_zero_extent() {
+        let mut sym = Symbol::new(SymbolType::Code128);
+        sym.add_point(7, 11);
+        assert_eq!(
+            sym.bounds(),
+            Some(Bounds {
+                x: 7,
+                y: 11,
+                width: 0,
+                height: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn test_bounds_aabb_of_qr_corners() {
+        let mut sym = Symbol::new(SymbolType::QrCode);
+        // Corners pushed in qrdec's [0, 2, 3, 1] order; bounds() must be
+        // independent of insertion order.
+        sym.add_point(88, 1996);
+        sym.add_point(211, 2121);
+        sym.add_point(88, 2121);
+        sym.add_point(211, 1996);
+        assert_eq!(sym.points().len(), 4);
+        assert_eq!(
+            sym.bounds(),
+            Some(Bounds {
+                x: 88,
+                y: 1996,
+                width: 123,
+                height: 125,
+            })
+        );
+    }
+
+    #[test]
+    fn test_bounds_with_negative_coordinates() {
+        let mut sym = Symbol::new(SymbolType::Code128);
+        sym.add_point(-3, -7);
+        sym.add_point(2, 4);
+        assert_eq!(
+            sym.bounds(),
+            Some(Bounds {
+                x: -3,
+                y: -7,
+                width: 5,
+                height: 11,
+            })
+        );
     }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -69,12 +69,71 @@ impl ScanOptions {
     }
 }
 
+/// A 2D pixel coordinate in image space.
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[wasm_bindgen]
+impl Point {
+    #[wasm_bindgen(getter)]
+    pub fn x(&self) -> i32 {
+        self.x
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn y(&self) -> i32 {
+        self.y
+    }
+}
+
+/// Axis-aligned bounding rectangle of a decoded symbol in image
+/// coordinates. `width` and `height` are reported as `max - min` of the
+/// recorded points (i.e. the horizontal and vertical extent between the
+/// outermost points), not as a pixel count.
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub struct Bounds {
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+}
+
+#[wasm_bindgen]
+impl Bounds {
+    #[wasm_bindgen(getter)]
+    pub fn x(&self) -> i32 {
+        self.x
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn y(&self) -> i32 {
+        self.y
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+}
+
 /// A decoded barcode/QR code result.
 #[wasm_bindgen]
 pub struct DecodeResult {
     symbol_type: String,
     data: Vec<u8>,
     text: Option<String>,
+    points: Vec<Point>,
+    bounds: Option<Bounds>,
 }
 
 #[wasm_bindgen]
@@ -102,6 +161,24 @@ impl DecodeResult {
     #[wasm_bindgen(getter)]
     pub fn text(&self) -> Option<String> {
         self.text.clone()
+    }
+
+    /// The recorded position points of this symbol in image coordinates.
+    ///
+    /// For QR codes, this is the four corner points of the QR's bounding
+    /// rectangle (in implementation-defined order). For linear barcodes,
+    /// this is one or more touchpoints accumulated as the symbol was
+    /// scanned. Empty if no points were recorded.
+    #[wasm_bindgen(getter)]
+    pub fn points(&self) -> Vec<Point> {
+        self.points.clone()
+    }
+
+    /// The axis-aligned bounding rectangle of this symbol's recorded
+    /// points, or `null` if no points were recorded.
+    #[wasm_bindgen(getter)]
+    pub fn bounds(&self) -> Option<Bounds> {
+        self.bounds
     }
 }
 
@@ -147,10 +224,25 @@ pub fn scan_grayscale(
 
     Ok(symbols
         .into_iter()
-        .map(|s| DecodeResult {
-            symbol_type: s.symbol_type().to_string(),
-            data: s.raw_data().unwrap_or(s.data()).to_vec(),
-            text: s.data_string().map(|t| t.to_string()),
+        .map(|s| {
+            let points = s
+                .points()
+                .iter()
+                .map(|p| Point { x: p.x, y: p.y })
+                .collect();
+            let bounds = s.bounds().map(|b| Bounds {
+                x: b.x,
+                y: b.y,
+                width: b.width,
+                height: b.height,
+            });
+            DecodeResult {
+                symbol_type: s.symbol_type().to_string(),
+                data: s.raw_data().unwrap_or(s.data()).to_vec(),
+                text: s.data_string().map(|t| t.to_string()),
+                points,
+                bounds,
+            }
         })
         .collect())
 }


### PR DESCRIPTION
Add `Symbol::points()` returning the recorded image-coordinate touchpoints and `Symbol::bounds()` returning their axis-aligned bounding rectangle as a new public `Bounds` struct.

For QR codes the points are the four corners of the symbol's bounding rectangle (recorded by the qrdec decoder); for linear barcodes they are the per-scan-line touchpoints accumulated when position tracking is enabled. Previously these positions were stored on `Symbol` but only accessible to crate-internal code, which forced callers that wanted to locate a symbol in the source image to fall back to the full scanned region.