### PR TITLE
docs: correct the API the READMEs describe

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a port of the ZBar library to Rust, providing barcode detection and deco
 
 ## Features
 
-- **Multiple Barcode Formats**: QR Code, EAN-13, EAN-8, UPC-A, UPC-E, ISBN-10, ISBN-13, Code 128, Code 93, Code 39, Codabar, Interleaved 2 of 5, DataBar (RSS), SQCode
+- **Multiple Barcode Formats**: QR Code, EAN-13, EAN-8, EAN-2, EAN-5, UPC-A, UPC-E, ISBN-10, ISBN-13, Code 128, Code 93, Code 39, Codabar, Interleaved 2 of 5, DataBar (RSS), DataBar Expanded, SQCode
 - **Pure Rust**: No C dependencies, fully memory-safe implementation
 - **Type-Safe Configuration**: Compile-time validated configuration API
 - **Command-line Tool**: `zedbarimg` utility for scanning images from the command line
@@ -31,12 +31,12 @@ cargo add zedbar --no-default-features --features qrcode,ean
 
 - `qrcode` - QR Code 2D barcode
 - `sqcode` - SQ Code 2D barcode
-- `ean` - EAN-8, EAN-13, UPC-A, UPC-E, ISBN-10, ISBN-13
+- `ean` - EAN-8, EAN-13, EAN-2, EAN-5, UPC-A, UPC-E, ISBN-10, ISBN-13
 - `code128` - Code 128
 - `code39` - Code 39
 - `code93` - Code 93
 - `codabar` - Codabar
-- `databar` - GS1 DataBar (RSS)
+- `databar` - GS1 DataBar (RSS) and DataBar Expanded
 - `i25` - Interleaved 2 of 5
 
 #### Optional Dependencies
@@ -46,6 +46,7 @@ cargo add zedbar --no-default-features --features qrcode,ean
 - `encoding_rs`, `reed-solomon`, `rand`, `rand_chacha` - Required for QR code decoding (enabled with `qrcode` feature)
 - `image` - Image format loading (PNG, JPEG, etc.) - needed for tests and the `zedbarimg` binary
 - `clap` - Command-line parsing (needed for the `zedbarimg` binary)
+- `wasm-bindgen`, `js-sys`, `getrandom` - JavaScript bindings (enabled with the `wasm` feature, which is off by default and builds the [npm package](npm/README.md))
 
 **Note:** 1D barcode decoders (EAN, Code39, Code128, etc.) have **zero external dependencies**!
 
@@ -78,13 +79,11 @@ Note: Disabling a feature at compile-time means that symbology will not be compi
 ```rust
 use zedbar::{Image, Scanner};
 
-// Load and convert image to grayscale
+// Load an image and convert it for scanning
 let img = image::open("barcode.png")?;
-let gray = img.to_luma8();
-let (width, height) = gray.dimensions();
+let mut img = Image::from_dynamic(&img)?;
 
 // Create scanner and scan image
-let mut img = Image::from_gray(gray.as_raw(), width, height)?;
 let mut scanner = Scanner::new();
 let symbols = scanner.scan(&mut img);
 
@@ -94,9 +93,16 @@ for symbol in symbols {
 }
 ```
 
+`Image::from_dynamic` (available with the `image` feature) composites any
+transparency over white before converting to grayscale. Prefer it over
+`img.to_luma8()`: a barcode drawn in black on a transparent background — the
+usual shape of one rendered from SVG — loses its alpha in a direct conversion
+and becomes black on black. If you already hold grayscale pixels, pass them
+straight to `Image::from_gray(data, width, height)`.
+
 ### Locating a Symbol in the Image
 
-Each [`Symbol`] records the image-coordinate points where it was detected,
+Each symbol records the image-coordinate points where it was detected,
 which lets you draw a box around the decode or crop the source image.
 
 ```rust
@@ -168,17 +174,20 @@ automatic retry:
 use zedbar::config::*;
 use zedbar::{DecoderConfig, Scanner, Image};
 
-// Option 1: Automatic retry (crop + 4x upscale)
+// Option 1: Automatic retry. Each undecoded region is cropped, upscaled and
+// rescanned, and any QR or SQ code recovered from it joins the results with
+// its coordinates mapped back to the original image.
 let config = DecoderConfig::new()
     .enable(QrCode)
     .retry_undecoded_regions(true);
 let mut scanner = Scanner::with_config(config);
-let symbols = scanner.scan(&mut img);
+let result = scanner.scan(&mut img);
 
-// Option 2: Manual control via finder_region()
+// Option 2: Manual control via finder_regions(), which reports one entry per
+// cluster of finder patterns that did not yield a symbol.
 let mut scanner = Scanner::new();
 let result = scanner.scan(&mut img);
-if let Some(region) = result.finder_region() {
+for region in result.finder_regions() {
     let pad = region.width.max(region.height) / 2;
     let x = region.x.saturating_sub(pad);
     let y = region.y.saturating_sub(pad);
@@ -191,16 +200,40 @@ if let Some(region) = result.finder_region() {
 }
 ```
 
+With automatic retry, the regions left in `finder_regions()` are the ones the
+retry could not resolve.
+
 ### Command-line Tool
 
-```bash
-# Build the tool
-cargo build --release --bin zedbarimg
+`zedbarimg` scans one or more image files and prints what it finds, in the
+manner of ZBar's `zbarimg`:
 
-# Scan an image
-cargo run --bin zedbarimg examples/test-qr.png
-cargo run --bin zedbarimg examples/test-ean13.png
+```bash
+cargo install zedbar
+zedbarimg barcode.png qrcode.jpg
 ```
+
+`--quiet` prints only the decoded data, `--raw` leaves it unconverted by any
+charset, and `--disable-all` plus the `--enable-*` flags narrow the scan to
+chosen symbologies. `zedbarimg --help` lists them all.
+
+From a checkout of this repository, where the test images live:
+
+```bash
+# Install the binary from the working tree
+cargo install --path .
+zedbarimg examples/test-qr.png
+
+# Or run it without installing. Use --release: a debug build carries
+# overflow checks and no optimization, and scans far slower.
+cargo run --release --bin zedbarimg -- examples/test-ean13.png
+```
+
+### JavaScript
+
+The same scanner is published to npm as [`zedbar`](https://www.npmjs.com/package/zedbar),
+compiled to WebAssembly, with its own `zedbarimg` command. See
+[npm/README.md](npm/README.md).
 
 ## Testing
 
@@ -248,7 +281,7 @@ If this library doesn't meet your needs, consider these alternatives:
 - **[rqrr](https://crates.io/crates/rqrr)** - Pure Rust QR code reader with a different algorithm. Fast and reliable for QR codes specifically, but only supports QR codes.
 - **[bardecoder](https://crates.io/crates/bardecoder)** - Another Rust barcode decoder supporting various 1D formats.
 - **[rxing](https://crates.io/crates/rxing)** - Rust port of ZXing (Zebra Crossing) library, supports many formats.
-- **[quircs](https://crates.io/crates/quircs)** - Rust bindings to the quirc QR code library.
+- **[quircs](https://crates.io/crates/quircs)** - Pure Rust port of the quirc QR code library.
 
 ### C/C++ Libraries (via FFI)
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -2,13 +2,13 @@
 
 Fast QR code and barcode scanner for Node.js, powered by WebAssembly.
 
-A port of the [ZBar](http://zbar.sourceforge.net/) barcode scanning library from C to Rust, compiled to WebAssembly for use in Node.js.
+A port of the [ZBar](https://github.com/mchehab/zbar) barcode scanning library from C to Rust, compiled to WebAssembly for use in Node.js.
 
 ## Features
 
 - **Fast**: Native-speed scanning via WebAssembly
 - **No native dependencies**: Works on any platform Node.js supports
-- **Multiple formats**: QR Code, EAN-13, EAN-8, UPC-A, UPC-E, Code 128, Code 93, Code 39, Codabar, Interleaved 2 of 5, DataBar, SQ Code
+- **Multiple formats**: QR Code, EAN-13, EAN-8, EAN-2, EAN-5, UPC-A, UPC-E, ISBN-10, ISBN-13, Code 128, Code 93, Code 39, Codabar, Interleaved 2 of 5, DataBar, DataBar Expanded, SQ Code
 - **CLI tool**: Command-line `zedbarimg` binary for scanning images (similar to `zbarimg`)
 
 ## Installation
@@ -19,7 +19,12 @@ npm install zedbar
 
 ## Command-line Usage
 
-The package includes a `zedbarimg` command-line tool:
+The package includes a `zedbarimg` command-line tool. Install the package
+globally to put it on your `PATH`:
+
+```bash
+npm install -g zedbar
+```
 
 ```bash
 # Scan a single image
@@ -31,16 +36,18 @@ zedbarimg image1.png image2.jpg image3.webp
 # Quiet mode (only output barcode data)
 zedbarimg --quiet qrcode.png
 
+# Raw mode (decoded bytes, no charset conversion)
+zedbarimg --raw qrcode.png
+
 # Show help
 zedbarimg --help
 ```
 
-After installing globally, you can use it directly:
+Without a global install, run it as `npx --package=zedbar zedbarimg barcode.png`.
 
-```bash
-npm install -g zedbar
-zedbarimg barcode.png
-```
+It exits non-zero when a file cannot be read or no barcode is found, and prints
+a `scanned N barcode symbols` summary to stderr so the decoded data on stdout
+stays pipeable.
 
 ## Library Usage
 
@@ -72,6 +79,26 @@ for (const { symbolType, text } of scanGrayscale(data, width, height)) {
 }
 ```
 
+### Restrict what is scanned
+
+```javascript
+import { scanImageBytes, ScanOptions } from 'zedbar';
+
+const options = new ScanOptions();
+options.symbologies = ['QR-Code'];
+
+const results = scanImageBytes(imageBytes, options);
+```
+
+`ScanOptions` is a class: construct it with `new` and assign its properties.
+Passing a plain object literal throws `expected instance of ScanOptions`.
+
+The package is CommonJS, so `require` works too:
+
+```javascript
+const { scanImageBytes, ScanOptions } = require('zedbar');
+```
+
 ## API
 
 ### `scanImageBytes(bytes, options?)`
@@ -100,19 +127,24 @@ Scans grayscale image data for barcodes and QR codes.
 
 ### `ScanOptions`
 
+A class, not a plain object: construct it with `new ScanOptions()` and assign
+the properties you want. Both are write-only setters.
+
 - `retryUndecodedRegions` (`boolean`, default: `true`) - Automatically retry undecoded QR finder regions by cropping and upscaling. Disable to skip the retry and reduce processing time for images that are known to have sufficient resolution.
-- `symbologies` (`string[]`, optional) - Restrict scanning to the listed symbologies. When omitted, every supported symbology is enabled. Names match the `symbolType` field on results — see [Supported Formats](#supported-formats).
+- `symbologies` (`string[]`, optional) - Restrict scanning to the listed symbologies. When omitted, every supported symbology is enabled. Names match the `symbolType` field on results — see [Supported Formats](#supported-formats) — and are case-sensitive; an unrecognized name throws `unknown symbology: "..."`.
 
 ```javascript
 // Scan QR codes only
-const results = scanImageBytes(imageBytes, { symbologies: ['QR-Code'] });
+const options = new ScanOptions();
+options.symbologies = ['QR-Code'];
+const results = scanImageBytes(imageBytes, options);
 ```
 
 ### `DecodeResult`
 
-- `symbolType` (`string`) - Barcode format (e.g., `"QR-Code"`, `"EAN-13"`)
-- `data` (`Uint8Array`) - Raw decoded bytes
-- `text` (`string | undefined`) - Decoded data as UTF-8 string, or `undefined` if not valid UTF-8
+- `symbolType` (`string`) - Barcode format (e.g., `"QR-Code"`, `"EAN-13"`), or `"Partial"` for something read but incomplete — see [Supported Formats](#supported-formats)
+- `data` (`Uint8Array`) - Raw decoded bytes. For QR codes these are the bytes as encoded in the barcode, before any charset conversion; for SQ codes they are the sampled bit matrix, which is all that symbology decodes to.
+- `text` (`string | undefined`) - The data as a string. For QR codes the encoding is detected (UTF-8, Shift-JIS, Windows-1252, or whatever an ECI designator names) and converted; for linear barcodes the data is always ASCII. SQ codes carry arbitrary binary, so this is `undefined` for them unless those bytes happen to be valid UTF-8.
 - `points` (`Point[]`) - Position points in image coordinates. For QR codes, the four corners of the QR's bounding rectangle (in implementation-defined order). For linear barcodes, one or more touchpoints accumulated as the symbol was scanned. Empty if no points were recorded.
 - `bounds` (`Bounds | undefined`) - Axis-aligned bounding rectangle of `points`, or `undefined` if no points were recorded.
 
@@ -145,15 +177,26 @@ for (const result of scanImageBytes(imageBytes)) {
 | QR Code | `QR-Code` |
 | EAN-13 | `EAN-13` |
 | EAN-8 | `EAN-8` |
+| EAN-2 add-on | `EAN-2` |
+| EAN-5 add-on | `EAN-5` |
 | UPC-A | `UPC-A` |
 | UPC-E | `UPC-E` |
+| ISBN-10 | `ISBN-10` |
+| ISBN-13 | `ISBN-13` |
 | Code 128 | `CODE-128` |
 | Code 93 | `CODE-93` |
 | Code 39 | `CODE-39` |
 | Codabar | `Codabar` |
 | Interleaved 2 of 5 | `I2/5` |
 | DataBar | `DataBar` |
+| DataBar Expanded | `DataBar-Exp` |
 | SQ Code | `SQ-Code` |
+
+A result may also carry the `symbolType` `Partial`, which is not a format and
+cannot be passed to `symbologies`. It means something was read but not a whole
+symbol: a structured-append QR group with at least one of its codes missing
+from the image. Its `data` is the parts that were found, joined with a NUL byte
+wherever an absent part belongs.
 
 ## License
 

--- a/npm/bin/zedbarimg.mjs
+++ b/npm/bin/zedbarimg.mjs
@@ -75,13 +75,14 @@ Options:
 
 Supported formats:
   - Images: PNG, JPEG, BMP, WebP
-  - Barcodes: QR Code, EAN-13, EAN-8, UPC-A, UPC-E, Code 128, Code 93,
-              Code 39, Codabar, Interleaved 2/5, DataBar, SQ Code
+  - Barcodes: QR Code, EAN-13, EAN-8, EAN-2, EAN-5, UPC-A, UPC-E, ISBN-10,
+              ISBN-13, Code 128, Code 93, Code 39, Codabar,
+              Interleaved 2/5, DataBar, DataBar Expanded, SQ Code
 
 Examples:
   zedbarimg barcode.png
   zedbarimg --quiet qrcode.jpg
-  zedbarimg image1.png image2.jpg image3.gif
+  zedbarimg image1.png image2.jpg image3.webp
 `);
 }
 
@@ -107,7 +108,8 @@ function main() {
       results = zedbar.scanImageBytes(imageBytes);
     } catch (err) {
       if (!options.quiet) {
-        console.error(`Failed to scan image '${filename}': ${err.message}`);
+        // The WASM boundary throws a plain string, which has no `.message`.
+        console.error(`Failed to scan image '${filename}': ${err.message ?? err}`);
       }
       process.exit(1);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,13 @@
 //! ```no_run
 //! use zedbar::{Image, Scanner};
 //!
-//! // Load and convert image to grayscale
+//! // Load an image and convert it for scanning. [`Image::from_dynamic`]
+//! // composites transparency over white; `to_luma8()` would drop the alpha
+//! // channel and leave a barcode on a transparent background black on black.
 //! let img = image::open("barcode.png").unwrap();
-//! let gray = img.to_luma8();
-//! let (width, height) = gray.dimensions();
+//! let mut img = Image::from_dynamic(&img).unwrap();
 //!
-//! // Create image and scanner
-//! let mut img = Image::from_gray(gray.as_raw(), width, height).unwrap();
+//! // Create a scanner
 //! let mut scanner = Scanner::new();
 //!
 //! // Scan for barcodes
@@ -23,6 +23,9 @@
 //!     println!("{:?}: {}", symbol.symbol_type(), symbol.data_string().unwrap_or(""));
 //! }
 //! ```
+//!
+//! If you already hold grayscale pixels, [`Image::from_gray`] takes them
+//! directly.
 //!
 //! # Configuration
 //!
@@ -55,9 +58,9 @@
 //! # Supported Formats
 //!
 //! - **2D Codes**: QR Code, SQCode
-//! - **Linear Codes**: EAN-13, EAN-8, UPC-A, UPC-E, ISBN-10, ISBN-13
+//! - **Linear Codes**: EAN-13, EAN-8, EAN-2, EAN-5, UPC-A, UPC-E, ISBN-10, ISBN-13
 //! - **Code Family**: Code 128, Code 93, Code 39, Codabar
-//! - **Industrial**: Interleaved 2 of 5, DataBar (RSS)
+//! - **Industrial**: Interleaved 2 of 5, DataBar (RSS), DataBar Expanded
 //!
 //! # Modules
 //!

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -361,8 +361,9 @@ impl std::str::FromStr for SymbolType {
     type Err = ParseSymbolTypeError;
 
     /// Parse a symbology by its [`Display`] name (e.g. `"QR-Code"`,
-    /// `"EAN-13"`, `"CODE-128"`). Recognises every variant in
-    /// [`SymbolType::ALL`].
+    /// `"EAN-13"`, `"CODE-128"`). Every symbology this library decodes is
+    /// recognised; `None`, `Partial` and `Composite` name states a symbol can
+    /// be in rather than symbologies, so they are not.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::ALL
             .iter()

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -14,15 +14,22 @@ use image;
 ///
 /// All fields are optional and default to sensible values when omitted.
 ///
+/// This is a class, not a plain object literal: construct it with `new` and
+/// assign the properties you want.
+///
 /// ```js
 /// // Use defaults (every supported symbology, retry enabled):
 /// const results = scanGrayscale(data, width, height);
 ///
 /// // Disable automatic retry of small QR codes:
-/// const results = scanGrayscale(data, width, height, { retryUndecodedRegions: false });
+/// const options = new ScanOptions();
+/// options.retryUndecodedRegions = false;
+/// const results = scanGrayscale(data, width, height, options);
 ///
 /// // Restrict to QR codes only:
-/// const results = scanGrayscale(data, width, height, { symbologies: ["QR-Code"] });
+/// const options = new ScanOptions();
+/// options.symbologies = ["QR-Code"];
+/// const results = scanGrayscale(data, width, height, options);
 /// ```
 #[wasm_bindgen]
 #[derive(Default)]


### PR DESCRIPTION
Both READMEs and the crate-level docs describe an API that has drifted from the code, and nothing checks any of it.

**Wrong API.** The Rust README's small-QR example calls `result.finder_region()`, which does not exist — it is `finder_regions()`, returning every undecoded cluster rather than one. The library example converts with `to_luma8()`, dropping the alpha channel that `Image::from_dynamic` exists to composite, so a barcode on a transparent background becomes black on black; the Quick Start in `src/lib.rs` taught the same thing. The JS README documents `ScanOptions` as an object literal; it is a wasm-bindgen class, and the documented call throws `expected instance of ScanOptions` — that same example is in the `src/wasm.rs` doc comment, so it ships in the generated `.d.ts`.

**Command line.** `cargo install` replaces a release `cargo build` followed by a debug `cargo run`. Separately, `npm/bin/zedbarimg.mjs` reported every failure as `Failed to scan image 'x.gif': undefined` — the value thrown across the WASM boundary has no `.message` — and its `--help` advertised GIF, which the WASM build cannot decode. That is the `fix` commit, kept separate so it gets released.

**Also.** Both READMEs and the crate docs were missing EAN-2, EAN-5 and DataBar Expanded (the READMEs also ISBN-10 and ISBN-13); the JS `symbolType` list gains `Partial`; `text` and `data` now say what they actually hold; and `FromStr` no longer links to `SymbolType::ALL`, which is private, so `cargo doc` is warning-free.

All five Rust snippets compile against the current API, and every JS claim was executed against a packed tarball rather than reasoned about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
